### PR TITLE
Fix cluster status parsing

### DIFF
--- a/api.go
+++ b/api.go
@@ -62,7 +62,7 @@ PeerLoop:
 			failureLog = append(failureLog, fmt.Sprintf("%s failed due to %s", url, err.Error()))
 			continue PeerLoop
 		}
-		trace("%s: http.NewRequest() OK")
+		trace("%s: http.NewRequest() OK", conn.ID)
 		req.Header.Set("Content-Type", "application/json")
 		client := &http.Client{}
 		client.Timeout = time.Duration(conn.timeout) * time.Second
@@ -73,14 +73,14 @@ PeerLoop:
 			continue PeerLoop
 		}
 		defer response.Body.Close()
-		trace("%s: client.Do() OK")
+		trace("%s: client.Do() OK", conn.ID)
 		responseBody, err := ioutil.ReadAll(response.Body)
 		if err != nil {
 			trace("%s: got error '%s' doing ioutil.ReadAll", conn.ID, err.Error())
 			failureLog = append(failureLog, fmt.Sprintf("%s failed due to %s", url, err.Error()))
 			continue PeerLoop
 		}
-		trace("%s: ioutil.ReadAll() OK")
+		trace("%s: ioutil.ReadAll() OK", conn.ID)
 		if response.Status != "200 OK" {
 			trace("%s: got code %s", conn.ID, response.Status)
 			failureLog = append(failureLog, fmt.Sprintf("%s failed, got: %s", url, response.Status))

--- a/cluster_test.go
+++ b/cluster_test.go
@@ -7,7 +7,7 @@ import "os"
 func TestInitCluster(t *testing.T) {
 
 	TraceOn(os.Stderr)
-	t.Logf("trying Open")
+	t.Logf("trying Open: %s\n", testUrl())
 	conn, err := Open(testUrl())
 	if err != nil {
 		t.Logf("--> FAILED")


### PR DESCRIPTION
When trying to use gorqlite against docker images of rqlite/latest (v4.5.0), it cannot find the leader node.

It looks like the structure of the json emitted by /status had changed, so code was updated to reflect the new structure.