### PR TITLE
fix test with default timestamp to give actually the current timestamp

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ jobs:
     working_directory: ~/rqlite/src/github.com/rqlite/gorqlite
     docker:
       - image: circleci/golang:1.12
-      - image: rqlite/rqlite:4.5.0
+      - image: rqlite/rqlite:5.3.0
     steps:
         - checkout
         - run: go vet .

--- a/query_test.go
+++ b/query_test.go
@@ -31,7 +31,7 @@ func TestQueryOne(t *testing.T) {
 	started := time.Now().Add(-time.Second)
 
 	t.Logf("trying WriteOne CREATE")
-	wr, err = conn.WriteOne("CREATE TABLE " + testTableName() + " (id integer, name text, ts DATETIME DEFAULT (datetime('now','utc')))")
+	wr, err = conn.WriteOne("CREATE TABLE " + testTableName() + " (id integer, name text, ts DATETIME DEFAULT CURRENT_TIMESTAMP)")
 	if err != nil {
 		t.Logf("--> FATAL")
 		t.Fatal()


### PR DESCRIPTION
Current default timestamp doesn't give the current timestamp (mine was 6 hours before).  
This fix should give the current timestamp to each insert and fix the tests.