### PR TITLE
do not crash when no time returned in result

### DIFF
--- a/query.go
+++ b/query.go
@@ -170,8 +170,11 @@ func (conn *Connection) Query(sqlStatements []string) (results []QueryResult, er
 			continue
 		}
 
-		// time is a float64
-		thisQR.Timing = thisResult["time"].(float64)
+		_, ok = thisResult["time"]
+		if ok {
+			// time is a float64
+			thisQR.Timing = thisResult["time"].(float64)
+		}
 
 		// column & type are an array of strings
 		c := thisResult["columns"].([]interface{})

--- a/write.go
+++ b/write.go
@@ -6,9 +6,11 @@ package gorqlite
 		WriteResult and its methods
 */
 
-import "errors"
-import "encoding/json"
-import "fmt"
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+)
 
 /* *****************************************************************
 
@@ -143,7 +145,11 @@ func (conn *Connection) Write(sqlStatements []string) (results []WriteResult, er
 		if ok {
 			thisWR.RowsAffected = int64(thisResult["rows_affected"].(float64))
 		}
-		thisWR.Timing = thisResult["time"].(float64)
+
+		_, ok = thisResult["time"]
+		if ok {
+			thisWR.Timing = thisResult["time"].(float64)
+		}
 
 		trace("%s: this result (LII,RA,T): %d %d %f", conn.ID, thisWR.LastInsertID, thisWR.RowsAffected, thisWR.Timing)
 		results = append(results, thisWR)


### PR DESCRIPTION
currently client crashes unable to cast none existent float when time is not returned.
protect against this scenario to prevent crash.