### PR TITLE
fix failover to another peer

### DIFF
--- a/cluster.go
+++ b/cluster.go
@@ -233,17 +233,19 @@ func (conn *Connection) updateClusterInfo() error {
 		}
 
 		for _, v := range nodes {
+			u, err := url.Parse(v.APIAddr)
+			if err != nil {
+				return errors.New("could not parse API address")
+			}
+			var host, port string
+			if host, port, err = net.SplitHostPort(u.Host); err != nil {
+				return fmt.Errorf("could not split host: %s", err)
+			}
+
 			if v.Leader {
-				u, err := url.Parse(v.APIAddr)
-				if err != nil {
-					return errors.New("could not parse API address")
-				}
-				trace("nodes/ indicates %s as API Addr", u.String())
-				var host, port string
-				if host, port, err = net.SplitHostPort(u.Host); err != nil {
-					return fmt.Errorf("could not split host: %s", err)
-				}
 				rc.leader = peer{host, port}
+			} else {
+				rc.otherPeers = append(rc.otherPeers, peer{host, port})
 			}
 		}
 	} else {


### PR DESCRIPTION
Running gorqlite against a cluster of 3 rqlite nodes, when the leader goes down gorqlite doesn't seem to be failing other to another peer (even though the rqlite has successfully elected another node in the cluster).

I get log `tried all peers unsuccessfully. here are the results` which only shows it attempted the original leader rather than the other peers.

This may well be something I've configured wrong, though it looks like gorqlite just iterates though `rqliteCluster.otherPeers` which seems to be unmodified - so this PR just adds the non-leader peers to `rqliteCluster.otherPeers` in the same way it adds `rqliteCluster.leader`.

Testing terminating the leader node seems to fail over now trying upto 3 peers as needed with this fix.