### PR TITLE
peer list fixes

### DIFF
--- a/cluster.go
+++ b/cluster.go
@@ -43,6 +43,10 @@ type peer struct {
 	port     string //   "4001" or port, only ever used as a string
 }
 
+func (p *peer) Empty() bool {
+	return p.hostname == "" && p.port == ""
+}
+
 func (p *peer) String() string {
 	return fmt.Sprintf("%s:%s", p.hostname, p.port)
 }
@@ -74,7 +78,9 @@ type rqliteCluster struct {
 func (rc *rqliteCluster) makePeerList() []peer {
 	trace("%s: makePeerList() called", rc.conn.ID)
 	var peerList []peer
-	peerList = append(peerList, rc.leader)
+	if !rc.leader.Empty() {
+		peerList = append(peerList, rc.leader)
+	}
 	for _, p := range rc.otherPeers {
 		peerList = append(peerList, p)
 	}

--- a/cluster.go
+++ b/cluster.go
@@ -233,6 +233,10 @@ func (conn *Connection) updateClusterInfo() error {
 		}
 
 		for _, v := range nodes {
+			if !v.Reachable {
+				continue
+			}
+
 			u, err := url.Parse(v.APIAddr)
 			if err != nil {
 				return errors.New("could not parse API address")

--- a/conn.go
+++ b/conn.go
@@ -137,7 +137,9 @@ func (conn *Connection) Peers() ([]string, error) {
 	} else {
 		trace("%s: Peers(), updateClusterInfo() OK", conn.ID)
 	}
-	plist = append(plist, conn.cluster.leader.String())
+	if !conn.cluster.leader.Empty() {
+		plist = append(plist, conn.cluster.leader.String())
+	}
 	for _, p := range conn.cluster.otherPeers {
 		plist = append(plist, p.String())
 	}


### PR DESCRIPTION
Two small fixes:

* fix: skip peers with unknown `APIAddr`:
When a node is unreachable `APIAddr` is empty (https://github.com/rqlite/rqlite/blob/master/http/service.go#L1100) so `net.SplitHostPort(u.Host)` is returning an error.
Maybe this is expected though currently calls like `conn.Leader()` and `conn.Peers()` are failing even when a new leader has been elected.

* fix: dont connect to empty peer:
When the leader is not yet set the client tries to connect to `http://:` as hoth host and port are empty strings though is still in the 'peer list' - seems better just to break early?