### PR TITLE
Fixes and api.go optimizations

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,9 +94,9 @@ var name string
 rows, err := conn.QueryOne("select id, name from secret_agents where id > 500")
 fmt.Printf("query returned %d rows\n",rows.NumRows)
 for rows.Next() {
-	err := response.Scan(&id, &name)
-	fmt.Printf("this is row number %d\n",response.RowNumber)
-	fmt.Printf("there are %d rows overall%d\n",response.NumRows)
+	err := rows.Scan(&id, &name)
+	fmt.Printf("this is row number %d\n",rows.RowNumber)
+	fmt.Printf("there are %d rows overall%d\n",rows.NumRows)
 }
 
 // just like WriteOne()/Write(), QueryOne() takes a single statement,
@@ -107,7 +107,7 @@ for rows.Next() {
 // alternatively, use Next()/Map()
 
 for rows.Next() {
-	m, err := response.Map()
+	m, err := rows.Map()
 	// m is now a map[column name as string]interface{}
 	id := m["name"].(float64) // the only json number type
 	name := m["name"].(string)

--- a/api.go
+++ b/api.go
@@ -13,13 +13,14 @@ package gorqlite
 
 */
 
-import "bytes"
-import "encoding/json"
-import "errors"
-import "fmt"
-import "io/ioutil"
-import "net/http"
-import "time"
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+)
 
 /* *****************************************************************
 
@@ -64,9 +65,7 @@ PeerLoop:
 		}
 		trace("%s: http.NewRequest() OK", conn.ID)
 		req.Header.Set("Content-Type", "application/json")
-		client := &http.Client{}
-		client.Timeout = time.Duration(conn.timeout) * time.Second
-		response, err := client.Do(req)
+		response, err := conn.client.Do(req)
 		if err != nil {
 			trace("%s: got error '%s' doing client.Do", conn.ID, err.Error())
 			failureLog = append(failureLog, fmt.Sprintf("%s failed due to %s", url, err.Error()))
@@ -162,8 +161,7 @@ PeerLoop:
 				continue PeerLoop
 			}
 			req.Header.Set("Content-Type", "application/json")
-			client := &http.Client{}
-			response, err := client.Do(req)
+			response, err := conn.client.Do(req)
 			if err != nil {
 				trace("%s: got error '%s' doing client.Do", conn.ID, err.Error())
 				failureLog = append(failureLog, fmt.Sprintf("%s failed due to %s", url, err.Error()))

--- a/api.go
+++ b/api.go
@@ -33,7 +33,7 @@ import (
  * *****************************************************************/
 func (conn *Connection) rqliteApiCall(apiOp apiOperation, method string, requestBody []byte) ([]byte, error) {
 	// Verify that we have at least a single peer to which we can make the request
-	peers := conn.cluster.makePeerList()
+	peers := conn.cluster.PeerList()
 	if len(peers) < 1 {
 		return nil, errors.New("I don't have any cluster info")
 	}

--- a/api.go
+++ b/api.go
@@ -20,11 +20,87 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"strings"
 )
 
 /* *****************************************************************
+   method: rqliteApiCall() - internally handles api calls,
+	 													 not supposed to be used by other files
 
-   method: rqliteApiGet() - for api_STATUS
+	- handles retries
+	- handles timeouts
+
+ * *****************************************************************/
+func (conn *Connection) rqliteApiCall(apiOp apiOperation, method string, requestBody []byte) ([]byte, error) {
+	// Verify that we have at least a single peer to which we can make the request
+	peers := conn.cluster.makePeerList()
+	if len(peers) < 1 {
+		return nil, errors.New("I don't have any cluster info")
+	}
+	trace("%s: I have a peer list %d peers long", conn.ID, len(peers))
+
+	// Keep list of failed requests to each peer, return in case all peers fail to answer
+	var failureLog []string
+
+	for i, peer := range peers {
+		trace("%s: attemping to contact peer %d", conn.ID, i)
+		url := conn.assembleURL(apiOp, peer)
+
+		// Prepare request
+		req, err := http.NewRequest(method, url, bytes.NewBuffer(requestBody))
+		if err != nil {
+			trace("%s: got error '%s' doing http.NewRequest", conn.ID, err.Error())
+			failureLog = append(failureLog, fmt.Sprintf("%s failed due to %s", url, err.Error()))
+			continue
+		}
+		trace("%s: http.NewRequest() OK", conn.ID)
+		req.Header.Set("Content-Type", "application/json")
+
+		// Execute request using shared client
+		// We will close the response body as soon as we can to allow
+		// the TCP connection to escape back into client's pool
+		response, err := conn.client.Do(req)
+		if err != nil {
+			trace("%s: got error '%s' doing client.Do", conn.ID, err.Error())
+			failureLog = append(failureLog, fmt.Sprintf("%s failed due to %s", url, err.Error()))
+			continue
+		}
+
+		// Check response code before reading body
+		if response.StatusCode != http.StatusOK {
+			trace("%s: got code %s", conn.ID, response.Status)
+			failureLog = append(failureLog, fmt.Sprintf("%s failed, got: %s", url, response.Status))
+			response.Body.Close()
+			continue
+		}
+
+		// Read response body now that we've got a successful answer
+		trace("%s: client.Do() OK", conn.ID)
+		responseBody, err := ioutil.ReadAll(response.Body)
+		if err != nil {
+			trace("%s: got error '%s' doing ioutil.ReadAll", conn.ID, err.Error())
+			failureLog = append(failureLog, fmt.Sprintf("%s failed due to %s", url, err.Error()))
+			response.Body.Close()
+			continue
+		}
+		response.Body.Close()
+		trace("%s: ioutil.ReadAll() OK", conn.ID)
+
+		return responseBody, nil
+	}
+
+	// All peers have failed to answer us, build a verbose error message
+	var builder strings.Builder
+	builder.WriteString("tried all peers unsuccessfully. here are the results:\n")
+	for n, v := range failureLog {
+		builder.WriteString(fmt.Sprintf("   peer #%d: %s\n", n, v))
+	}
+	return nil, errors.New(builder.String())
+}
+
+/* *****************************************************************
+
+   method: rqliteApiGet() - for api_STATUS and api_NODES
 
 	- lowest level interface - does not do any JSON unmarshaling
 	- handles retries
@@ -36,67 +112,12 @@ func (conn *Connection) rqliteApiGet(apiOp apiOperation) ([]byte, error) {
 	var responseBody []byte
 	trace("%s: rqliteApiGet() called", conn.ID)
 
-	// only api_STATUS now - maybe someday BACKUP
+	// Allow only api_STATUS and api_NODES now - maybe someday BACKUP
 	if apiOp != api_STATUS && apiOp != api_NODES {
 		return responseBody, errors.New("rqliteApiGet() called for invalid api operation")
 	}
 
-	// just to be safe, check this
-	peersToTry := conn.cluster.makePeerList()
-	if len(peersToTry) < 1 {
-		return responseBody, errors.New("I don't have any cluster info")
-	}
-	trace("%s: I have a peer list %d peers long", conn.ID, len(peersToTry))
-
-	// failure log is used so that if all peers fail, we can say something
-	// about why each failed
-	failureLog := make([]string, 0)
-
-PeerLoop:
-	for peerNum, peerToTry := range peersToTry {
-		trace("%s: attemping to contact peer %d", conn.ID, peerNum)
-		// docs say default GET policy is up to 10 follows automatically
-		url := conn.assembleURL(apiOp, peerToTry)
-		req, err := http.NewRequest("GET", url, nil)
-		if err != nil {
-			trace("%s: got error '%s' doing http.NewRequest", conn.ID, err.Error())
-			failureLog = append(failureLog, fmt.Sprintf("%s failed due to %s", url, err.Error()))
-			continue PeerLoop
-		}
-		trace("%s: http.NewRequest() OK", conn.ID)
-		req.Header.Set("Content-Type", "application/json")
-		response, err := conn.client.Do(req)
-		if err != nil {
-			trace("%s: got error '%s' doing client.Do", conn.ID, err.Error())
-			failureLog = append(failureLog, fmt.Sprintf("%s failed due to %s", url, err.Error()))
-			continue PeerLoop
-		}
-		defer response.Body.Close()
-		trace("%s: client.Do() OK", conn.ID)
-		responseBody, err := ioutil.ReadAll(response.Body)
-		if err != nil {
-			trace("%s: got error '%s' doing ioutil.ReadAll", conn.ID, err.Error())
-			failureLog = append(failureLog, fmt.Sprintf("%s failed due to %s", url, err.Error()))
-			continue PeerLoop
-		}
-		trace("%s: ioutil.ReadAll() OK", conn.ID)
-		if response.Status != "200 OK" {
-			trace("%s: got code %s", conn.ID, response.Status)
-			failureLog = append(failureLog, fmt.Sprintf("%s failed, got: %s", url, response.Status))
-			continue PeerLoop
-		}
-		// if we got here, we succeeded
-		trace("%s: api call OK, returning", conn.ID)
-		return responseBody, nil
-	}
-
-	// if we got here, all peers failed.  Let's build a verbose error message
-	var stringBuffer bytes.Buffer
-	stringBuffer.WriteString("tried all peers unsuccessfully. here are the results:\n")
-	for n, v := range failureLog {
-		stringBuffer.WriteString(fmt.Sprintf("   peer #%d: %s\n", n, v))
-	}
-	return responseBody, errors.New(stringBuffer.String())
+	return conn.rqliteApiCall(apiOp, "GET", nil)
 }
 
 /* *****************************************************************
@@ -104,98 +125,25 @@ PeerLoop:
    method: rqliteApiPost() - for api_QUERY and api_WRITE
 
 	- lowest level interface - does not do any JSON unmarshaling
- 	- handles 301s, etc.
 	- handles retries
 	- handles timeouts
-
-	it is called with an apiOperation type because the URL it will use varies
-	depending on the API operation type (api_QUERY vs. api_WRITE)
 
  * *****************************************************************/
 
 func (conn *Connection) rqliteApiPost(apiOp apiOperation, sqlStatements []string) ([]byte, error) {
 	var responseBody []byte
 
-	switch apiOp {
-	case api_QUERY:
-		trace("%s: rqliteApiGet() post called for a QUERY of %d statements", conn.ID, len(sqlStatements))
-	case api_WRITE:
-		trace("%s: rqliteApiGet() post called for a QUERY of %d statements", conn.ID, len(sqlStatements))
-	default:
-		return responseBody, errors.New("weird! called for an invalid apiOperation in rqliteApiPost()")
+	// Allow only api_QUERY and api_WRITE
+	if apiOp != api_QUERY && apiOp != api_WRITE {
+		return responseBody, errors.New("rqliteApiPost() called for invalid api operation")
 	}
 
-	// jsonify the statements.  not really needed in the
-	// case of api_STATUS but doesn't hurt
+	trace("%s: rqliteApiPost() called for a QUERY of %d statements", conn.ID, len(sqlStatements))
 
-	jStatements, err := json.Marshal(sqlStatements)
+	// Send statements as json
+	body, err := json.Marshal(sqlStatements)
 	if err != nil {
 		return nil, err
 	}
-
-	// just to be safe, check this
-	peersToTry := conn.cluster.makePeerList()
-	if len(peersToTry) < 1 {
-		return responseBody, errors.New("I don't have any cluster info")
-	}
-
-	// failure log is used so that if all peers fail, we can say something
-	// about why each failed
-	failureLog := make([]string, 0)
-
-PeerLoop:
-	for peerNum, peer := range peersToTry {
-		trace("%s: trying peer #%d", conn.ID, peerNum)
-
-		// we're doing a post, and the RFCs say that if you get a 301, it's not
-		// automatically followed, so we have to do that ourselves
-
-		responseStatus := "Haven't Tried Yet"
-		var url string
-		for responseStatus == "Haven't Tried Yet" || responseStatus == "301 Moved Permanently" {
-			url = conn.assembleURL(apiOp, peer)
-			req, err := http.NewRequest("POST", url, bytes.NewBuffer(jStatements))
-			if err != nil {
-				trace("%s: got error '%s' doing http.NewRequest", conn.ID, err.Error())
-				failureLog = append(failureLog, fmt.Sprintf("%s failed due to %s", url, err.Error()))
-				continue PeerLoop
-			}
-			req.Header.Set("Content-Type", "application/json")
-			response, err := conn.client.Do(req)
-			if err != nil {
-				trace("%s: got error '%s' doing client.Do", conn.ID, err.Error())
-				failureLog = append(failureLog, fmt.Sprintf("%s failed due to %s", url, err.Error()))
-				continue PeerLoop
-			}
-			defer response.Body.Close()
-			responseBody, err = ioutil.ReadAll(response.Body)
-			if err != nil {
-				trace("%s: got error '%s' doing ioutil.ReadAll", conn.ID, err.Error())
-				failureLog = append(failureLog, fmt.Sprintf("%s failed due to %s", url, err.Error()))
-				continue PeerLoop
-			}
-			responseStatus = response.Status
-			if responseStatus == "301 Moved Permanently" {
-				v := response.Header["Location"]
-				failureLog = append(failureLog, fmt.Sprintf("%s redirected me to %s", url, v[0]))
-				url = v[0]
-				continue PeerLoop
-			} else if responseStatus == "200 OK" {
-				trace("%s: api call OK, returning", conn.ID)
-				return responseBody, nil
-			} else {
-				trace("%s: got error in responseStatus: %s", conn.ID, responseStatus)
-				failureLog = append(failureLog, fmt.Sprintf("%s failed, got: %s", url, response.Status))
-				continue PeerLoop
-			}
-		}
-	}
-
-	// if we got here, all peers failed.  Let's build a verbose error message
-	var stringBuffer bytes.Buffer
-	stringBuffer.WriteString("tried all peers unsuccessfully. here are the results:\n")
-	for n, v := range failureLog {
-		stringBuffer.WriteString(fmt.Sprintf("   peer #%d: %s\n", n, v))
-	}
-	return responseBody, errors.New(stringBuffer.String())
+	return conn.rqliteApiCall(apiOp, "POST", body)
 }

--- a/cluster_test.go
+++ b/cluster_test.go
@@ -1,11 +1,11 @@
 package gorqlite
 
-import "testing"
-
-import "os"
+import (
+	"os"
+	"testing"
+)
 
 func TestInitCluster(t *testing.T) {
-
 	TraceOn(os.Stderr)
 	t.Logf("trying Open: %s\n", testUrl())
 	conn, err := Open(testUrl())

--- a/conn.go
+++ b/conn.go
@@ -278,7 +278,7 @@ func (conn *Connection) initConnection(url string) error {
 
 	// parse query params
 	query := u.Query()
-	if query.Has("level") {
+	if query.Get("level") != "" {
 		cl, ok := consistencyLevels[query.Get("level")]
 		if !ok {
 			return errors.New("invalid consistency level: " + query.Get("level"))
@@ -287,7 +287,7 @@ func (conn *Connection) initConnection(url string) error {
 	}
 
 	timeout := defaultTimeout
-	if query.Has("timeout") {
+	if query.Get("timeout") != "" {
 		customTimeout, err := strconv.Atoi(query.Get("timeout"))
 		if err != nil {
 			return errors.New("invalid timeout specified: " + err.Error())

--- a/conn.go
+++ b/conn.go
@@ -264,6 +264,7 @@ func (conn *Connection) initConnection(url string) error {
 	} else {
 		conn.cluster.leader = peer(u.Host)
 	}
+	conn.cluster.peerList = []peer{conn.cluster.leader}
 
 	/*
 

--- a/gorqlite.go
+++ b/gorqlite.go
@@ -19,11 +19,13 @@ package gorqlite
 		Open, TraceOn(), TraceOff()
 */
 
-import "crypto/rand"
-import "fmt"
-import "io"
-import "io/ioutil"
-import "strings"
+import (
+	"crypto/rand"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"strings"
+)
 
 /* *****************************************************************
 
@@ -40,8 +42,10 @@ const (
 )
 
 // used in several places, actually
-var consistencyLevelNames map[consistencyLevel]string
-var consistencyLevels map[string]consistencyLevel
+var (
+	consistencyLevelNames map[consistencyLevel]string
+	consistencyLevels     map[string]consistencyLevel
+)
 
 type apiOperation int
 
@@ -70,7 +74,6 @@ func init() {
 	consistencyLevels["none"] = cl_NONE
 	consistencyLevels["weak"] = cl_WEAK
 	consistencyLevels["strong"] = cl_STRONG
-
 }
 
 /* *****************************************************************
@@ -104,7 +107,6 @@ func Open(connURL string) (Connection, error) {
 	trace("%s: Open() called for url: %s", conn.ID, connURL)
 
 	// set defaults
-	conn.timeout = 10
 	conn.hasBeenClosed = false
 
 	// parse the URL given

--- a/query_test.go
+++ b/query_test.go
@@ -177,5 +177,4 @@ func TestQueryOne(t *testing.T) {
 		t.Fail()
 	}
 	_ = qResults
-
 }

--- a/write_test.go
+++ b/write_test.go
@@ -55,7 +55,6 @@ func TestWriteOne(t *testing.T) {
 		t.Logf("--> FAILED")
 		t.Fail()
 	}
-
 }
 
 func TestWrite(t *testing.T) {
@@ -104,5 +103,4 @@ func TestWrite(t *testing.T) {
 		t.Logf("--> FAILED")
 		t.Fail()
 	}
-
 }


### PR DESCRIPTION
Hi! I've introduced lots of fixes and small optimizations, as well as some big ones regarding api.go (http calls):
- fix: proper query parameter parsing for Open(), now timeout query parameter actually works
- fix: timeout for http client is now used for apiPost calls, not only GET
- optimization: strings.Builder instead of bytes.Buffer for string concatenation
- optimization: peer list caching since it changes only during updateClusterInfo()
- optimization: shared http.Client is used for the Connection in order to reuse TCP connections and other resources, like the golang documentation for net/http Client specifies

Also fixed some small example errors in README.
I know that this repo is temporary, however, since it's here to stay at least for now, I think these changes should be included :) 