### PR TITLE
feat: context support, pointer of connection, exported ErrClosed, parameterized queries

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,12 +3,12 @@ jobs:
   test:
     working_directory: ~/rqlite/src/github.com/rqlite/gorqlite
     docker:
-      - image: circleci/golang:1.12
+      - image: circleci/golang@sha256:bf91f089cecab7fcd329193022794e7d13c42ee4570b1ac2920875c1b948eb63
       - image: rqlite/rqlite:latest
     steps:
-        - checkout
-        - run: go vet .
-        - run: go test -timeout 60s -v ./...
+      - checkout
+      - run: go vet .
+      - run: go test -timeout 60s -v ./...
 
 workflows:
   version: 2

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,25 @@
+# If you prefer the allow list template instead of the deny list, see community template:
+# https://github.com/github/gitignore/blob/main/community/Golang/Go.AllowList.gitignore
+#
+# Binaries for programs and plugins
+*.exe
+*.exe~
+*.dll
+*.so
+*.dylib
+
+# Test binary, built with `go test -c`
+*.test
+
+# Output of the go coverage tool, specifically when used with LiteIDE
+*.out
+
+# Dependency directories (remove the comment below to include it)
+# vendor/
+
+# Go workspace file
+go.work
+
+### Go Patch ###
+/vendor/
+/Godeps/

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,17 @@
-# If you prefer the allow list template instead of the deny list, see community template:
-# https://github.com/github/gitignore/blob/main/community/Golang/Go.AllowList.gitignore
-#
+### VisualStudioCode template
+.vscode/*
+*.code-workspace
+
+# Local History for Visual Studio Code
+.history/
+
+### JetBrains template
+# Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio, WebStorm and Rider
+# Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
+
+.idea/*
+
+### Go template
 # Binaries for programs and plugins
 *.exe
 *.exe~
@@ -17,9 +28,3 @@
 # Dependency directories (remove the comment below to include it)
 # vendor/
 
-# Go workspace file
-go.work
-
-### Go Patch ###
-/vendor/
-/Godeps/

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ gorqlite should be considered alpha until more testers share their experiences. 
 
 ## Install
 
-`go get github.com/rqlite/gorqlite`
+`go get github.com/rqlite/gorqlite/v2`
 
 ## Examples
 ```go

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ gorqlite should be considered alpha until more testers share their experiences. 
 
 ## Install
 
-`go get github.com/rqlite/gorqlite/v2`
+`go get github.com/rqlite/gorqlite`
 
 ## Examples
 ```go

--- a/api.go
+++ b/api.go
@@ -1,17 +1,14 @@
 package gorqlite
 
-/*
-	this file has low level stuff:
-
-	rqliteApiGet()
-	rqliteApiPost()
-
-	There is some code duplication between those and they should
-	probably be combined into one function.
-
-	nothing public here.
-
-*/
+// this file has low level stuff:
+//
+// rqliteApiGet()
+// rqliteApiPost()
+//
+// There is some code duplication between those and they should
+// probably be combined into one function.
+//
+// nothing public here.
 
 import (
 	"bytes"
@@ -23,14 +20,11 @@ import (
 	"strings"
 )
 
-/* *****************************************************************
-   method: rqliteApiCall() - internally handles api calls,
-	 													 not supposed to be used by other files
-
-	- handles retries
-	- handles timeouts
-
- * *****************************************************************/
+// method: rqliteApiCall() - internally handles api calls,
+// not supposed to be used by other files
+//
+// 	- handles retries
+// 	- handles timeouts
 func (conn *Connection) rqliteApiCall(apiOp apiOperation, method string, requestBody []byte) ([]byte, error) {
 	// Verify that we have at least a single peer to which we can make the request
 	peers := conn.cluster.PeerList()
@@ -98,16 +92,11 @@ func (conn *Connection) rqliteApiCall(apiOp apiOperation, method string, request
 	return nil, errors.New(builder.String())
 }
 
-/* *****************************************************************
-
-   method: rqliteApiGet() - for api_STATUS and api_NODES
-
-	- lowest level interface - does not do any JSON unmarshaling
-	- handles retries
-	- handles timeouts
-
- * *****************************************************************/
-
+//    method: rqliteApiGet() - for api_STATUS and api_NODES
+//
+// 	- lowest level interface - does not do any JSON unmarshaling
+// 	- handles retries
+// 	- handles timeouts
 func (conn *Connection) rqliteApiGet(apiOp apiOperation) ([]byte, error) {
 	var responseBody []byte
 	trace("%s: rqliteApiGet() called", conn.ID)
@@ -120,16 +109,11 @@ func (conn *Connection) rqliteApiGet(apiOp apiOperation) ([]byte, error) {
 	return conn.rqliteApiCall(apiOp, "GET", nil)
 }
 
-/* *****************************************************************
-
-   method: rqliteApiPost() - for api_QUERY and api_WRITE
-
-	- lowest level interface - does not do any JSON unmarshaling
-	- handles retries
-	- handles timeouts
-
- * *****************************************************************/
-
+//    method: rqliteApiPost() - for api_QUERY and api_WRITE
+//
+// 	- lowest level interface - does not do any JSON unmarshaling
+// 	- handles retries
+// 	- handles timeouts
 func (conn *Connection) rqliteApiPost(apiOp apiOperation, sqlStatements []string) ([]byte, error) {
 	var responseBody []byte
 

--- a/api.go
+++ b/api.go
@@ -16,7 +16,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 )
@@ -29,13 +29,13 @@ type ParameterizedStatement struct {
 // method: rqliteApiCall() - internally handles api calls,
 // not supposed to be used by other files
 //
-// 	- handles retries
-// 	- handles timeouts
+//   - handles retries
+//   - handles timeouts
 func (conn *Connection) rqliteApiCall(ctx context.Context, apiOp apiOperation, method string, requestBody []byte) ([]byte, error) {
 	// Verify that we have at least a single peer to which we can make the request
 	peers := conn.cluster.PeerList()
 	if len(peers) < 1 {
-		return nil, errors.New("I don't have any cluster info")
+		return nil, errors.New("don't have any cluster info")
 	}
 	trace("%s: I have a peer list %d peers long", conn.ID, len(peers))
 
@@ -76,15 +76,15 @@ func (conn *Connection) rqliteApiCall(ctx context.Context, apiOp apiOperation, m
 
 		// Read response body now that we've got a successful answer
 		trace("%s: client.Do() OK", conn.ID)
-		responseBody, err := ioutil.ReadAll(response.Body)
+		responseBody, err := io.ReadAll(response.Body)
 		if err != nil {
-			trace("%s: got error '%s' doing ioutil.ReadAll", conn.ID, err.Error())
+			trace("%s: got error '%s' doing io.ReadAll", conn.ID, err.Error())
 			failureLog = append(failureLog, fmt.Sprintf("%s failed due to %s", url, err.Error()))
 			response.Body.Close()
 			continue
 		}
 		response.Body.Close()
-		trace("%s: ioutil.ReadAll() OK", conn.ID)
+		trace("%s: io.ReadAll() OK", conn.ID)
 
 		return responseBody, nil
 	}
@@ -98,11 +98,11 @@ func (conn *Connection) rqliteApiCall(ctx context.Context, apiOp apiOperation, m
 	return nil, errors.New(builder.String())
 }
 
-//    method: rqliteApiGet() - for api_STATUS and api_NODES
+//	   method: rqliteApiGet() - for api_STATUS and api_NODES
 //
-// 	- lowest level interface - does not do any JSON unmarshaling
-// 	- handles retries
-// 	- handles timeouts
+//		- lowest level interface - does not do any JSON unmarshaling
+//		- handles retries
+//		- handles timeouts
 func (conn *Connection) rqliteApiGet(ctx context.Context, apiOp apiOperation) ([]byte, error) {
 	var responseBody []byte
 	trace("%s: rqliteApiGet() called", conn.ID)
@@ -115,11 +115,11 @@ func (conn *Connection) rqliteApiGet(ctx context.Context, apiOp apiOperation) ([
 	return conn.rqliteApiCall(ctx, apiOp, "GET", nil)
 }
 
-//    method: rqliteApiPost() - for api_QUERY and api_WRITE
+//	   method: rqliteApiPost() - for api_QUERY and api_WRITE
 //
-// 	- lowest level interface - does not do any JSON unmarshaling
-// 	- handles retries
-// 	- handles timeouts
+//		- lowest level interface - does not do any JSON unmarshaling
+//		- handles retries
+//		- handles timeouts
 func (conn *Connection) rqliteApiPost(ctx context.Context, apiOp apiOperation, sqlStatements []ParameterizedStatement) ([]byte, error) {
 	var responseBody []byte
 

--- a/api.go
+++ b/api.go
@@ -99,6 +99,8 @@ func (conn *Connection) rqliteApiCall(ctx context.Context, apiOp apiOperation, m
 	return nil, errors.New(builder.String())
 }
 
+// redactURL redacts URL from the given parameter to be
+// safely read by the client
 func redactURL(url string) string {
 	u, err := nurl.Parse(url)
 	if err != nil {

--- a/api.go
+++ b/api.go
@@ -134,6 +134,8 @@ func (conn *Connection) rqliteApiPost(ctx context.Context, apiOp apiOperation, s
 		return conn.rqliteApiCall(ctx, apiOp, "POST", body)
 	}
 
+	// If the parameters exists, whether is a single query or a batch,
+	// we should use the bulk API.
 	var bulkParameterizedBuilder [][]interface{}
 	for _, stmt := range sqlStatements {
 		bulkParameterizedBuilder = append(bulkParameterizedBuilder, []interface{}{stmt})

--- a/api_test.go
+++ b/api_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 )
 
-func Test_RedactURL(t *testing.T) {
+func TestRedactURL(t *testing.T) {
 	tests := []struct {
 		name string
 		url  string

--- a/closed_test.go
+++ b/closed_test.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/rqlite/gorqlite"
+	"github.com/rqlite/gorqlite/v2"
 )
 
 func TestClosedConnection(t *testing.T) {

--- a/closed_test.go
+++ b/closed_test.go
@@ -1,0 +1,206 @@
+package gorqlite_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/rqlite/gorqlite"
+)
+
+func TestClosedConnection(t *testing.T) {
+	conn, err := gorqlite.Open("http://")
+	if err != nil {
+		t.Errorf("failed to open connection: %v", err.Error())
+	}
+
+	// Now we close it
+	conn.Close()
+
+	t.Run("ConsistencyLevel", func(t *testing.T) {
+		_, err := conn.ConsistencyLevel()
+		if err == nil {
+			t.Errorf("expected error, got nil")
+		}
+
+		if !errors.Is(err, gorqlite.ErrClosed) {
+			t.Errorf("expected error to be ErrClosed, got %v", err)
+		}
+	})
+
+	t.Run("Leader", func(t *testing.T) {
+		_, err := conn.Leader()
+		if err == nil {
+			t.Errorf("expected error, got nil")
+		}
+
+		if !errors.Is(err, gorqlite.ErrClosed) {
+			t.Errorf("expected error to be ErrClosed, got %v", err)
+		}
+	})
+
+	t.Run("Peers", func(t *testing.T) {
+		_, err := conn.Peers()
+		if err == nil {
+			t.Errorf("expected error, got nil")
+		}
+
+		if !errors.Is(err, gorqlite.ErrClosed) {
+			t.Errorf("expected error to be ErrClosed, got %v", err)
+		}
+	})
+
+	t.Run("SetConsistencyLevel", func(t *testing.T) {
+		err := conn.SetConsistencyLevel(gorqlite.ConsistencyLevelNone)
+		if err == nil {
+			t.Errorf("expected error, got nil")
+		}
+
+		if !errors.Is(err, gorqlite.ErrClosed) {
+			t.Errorf("expected error to be ErrClosed, got %v", err)
+		}
+	})
+
+	t.Run("SetExecutionWithTransaction", func(t *testing.T) {
+		err := conn.SetExecutionWithTransaction(true)
+		if err == nil {
+			t.Errorf("expected error, got nil")
+		}
+
+		if !errors.Is(err, gorqlite.ErrClosed) {
+			t.Errorf("expected error to be ErrClosed, got %v", err)
+		}
+	})
+
+	t.Run("WriteOne", func(t *testing.T) {
+		_, err := conn.WriteOne("")
+		if err == nil {
+			t.Errorf("expected error, got nil")
+		}
+
+		if !errors.Is(err, gorqlite.ErrClosed) {
+			t.Errorf("expected error to be ErrClosed, got %v", err)
+		}
+	})
+
+	t.Run("WriteOneContext", func(t *testing.T) {
+		_, err := conn.WriteOneContext(context.Background(), "")
+		if err == nil {
+			t.Errorf("expected error, got nil")
+		}
+
+		if !errors.Is(err, gorqlite.ErrClosed) {
+			t.Errorf("expected error to be ErrClosed, got %v", err)
+		}
+	})
+
+	t.Run("QueueOne", func(t *testing.T) {
+		_, err := conn.QueueOne("")
+		if err == nil {
+			t.Errorf("expected error, got nil")
+		}
+
+		if !errors.Is(err, gorqlite.ErrClosed) {
+			t.Errorf("expected error to be ErrClosed, got %v", err)
+		}
+	})
+
+	t.Run("QueueOneContext", func(t *testing.T) {
+		_, err := conn.QueueOneContext(context.Background(), "")
+		if err == nil {
+			t.Errorf("expected error, got nil")
+		}
+
+		if !errors.Is(err, gorqlite.ErrClosed) {
+			t.Errorf("expected error to be ErrClosed, got %v", err)
+		}
+	})
+
+	t.Run("Write", func(t *testing.T) {
+		_, err := conn.Write([]string{})
+		if err == nil {
+			t.Errorf("expected error, got nil")
+		}
+
+		if !errors.Is(err, gorqlite.ErrClosed) {
+			t.Errorf("expected error to be ErrClosed, got %v", err)
+		}
+	})
+
+	t.Run("WriteContext", func(t *testing.T) {
+		_, err := conn.WriteContext(context.Background(), []string{})
+		if err == nil {
+			t.Errorf("expected error, got nil")
+		}
+
+		if !errors.Is(err, gorqlite.ErrClosed) {
+			t.Errorf("expected error to be ErrClosed, got %v", err)
+		}
+	})
+
+	t.Run("Queue", func(t *testing.T) {
+		_, err := conn.Queue([]string{})
+		if err == nil {
+			t.Errorf("expected error, got nil")
+		}
+
+		if !errors.Is(err, gorqlite.ErrClosed) {
+			t.Errorf("expected error to be ErrClosed, got %v", err)
+		}
+	})
+
+	t.Run("QueueContext", func(t *testing.T) {
+		_, err := conn.QueueContext(context.Background(), []string{})
+		if err == nil {
+			t.Errorf("expected error, got nil")
+		}
+
+		if !errors.Is(err, gorqlite.ErrClosed) {
+			t.Errorf("expected error to be ErrClosed, got %v", err)
+		}
+	})
+
+	t.Run("QueryOne", func(t *testing.T) {
+		_, err := conn.QueryOne("")
+		if err == nil {
+			t.Errorf("expected error, got nil")
+		}
+
+		if !errors.Is(err, gorqlite.ErrClosed) {
+			t.Errorf("expected error to be ErrClosed, got %v", err)
+		}
+	})
+
+	t.Run("QueryOneContext", func(t *testing.T) {
+		_, err := conn.QueryOneContext(context.Background(), "")
+		if err == nil {
+			t.Errorf("expected error, got nil")
+		}
+
+		if !errors.Is(err, gorqlite.ErrClosed) {
+			t.Errorf("expected error to be ErrClosed, got %v", err)
+		}
+	})
+
+	t.Run("Query", func(t *testing.T) {
+		_, err := conn.Query([]string{})
+		if err == nil {
+			t.Errorf("expected error, got nil")
+		}
+
+		if !errors.Is(err, gorqlite.ErrClosed) {
+			t.Errorf("expected error to be ErrClosed, got %v", err)
+		}
+	})
+
+	t.Run("QueryContext", func(t *testing.T) {
+		_, err := conn.QueryContext(context.Background(), []string{})
+		if err == nil {
+			t.Errorf("expected error, got nil")
+		}
+
+		if !errors.Is(err, gorqlite.ErrClosed) {
+			t.Errorf("expected error to be ErrClosed, got %v", err)
+		}
+	})
+}

--- a/closed_test.go
+++ b/closed_test.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/rqlite/gorqlite/v2"
+	"github.com/rqlite/gorqlite"
 )
 
 func TestClosedConnection(t *testing.T) {

--- a/closed_test.go
+++ b/closed_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestClosedConnection(t *testing.T) {
-	conn, err := gorqlite.Open("http://")
+	conn, err := gorqlite.Open(testUrl())
 	if err != nil {
 		t.Errorf("failed to open connection: %v", err.Error())
 	}

--- a/cluster.go
+++ b/cluster.go
@@ -49,9 +49,9 @@ func (rc *rqliteCluster) PeerList() []peer {
 // tell it what peer to talk to and what kind of API operation you're
 // making, and it will return the full URL, from start to finish.
 // e.g.:
-
+//
 // https://mary:secret2@server1.example.com:1234/db/query?transaction&level=strong
-
+//
 // note: this func needs to live at the Connection level because the
 // Connection holds the username, password, consistencyLevel, etc.
 func (conn *Connection) assembleURL(apiOp apiOperation, p peer) string {

--- a/cluster.go
+++ b/cluster.go
@@ -18,6 +18,7 @@ package gorqlite
  * *****************************************************************/
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"net/url"
@@ -119,7 +120,7 @@ func (conn *Connection) updateClusterInfo() error {
 	var rc rqliteCluster
 	rc.conn = conn
 
-	responseBody, err := conn.rqliteApiGet(api_STATUS)
+	responseBody, err := conn.rqliteApiGet(context.Background(), api_STATUS)
 	if err != nil {
 		return err
 	}
@@ -160,7 +161,7 @@ func (conn *Connection) updateClusterInfo() error {
 	if rc.leader == "" {
 		// nodes/ API is available in 6.0+
 		trace("getting leader from metadata failed, trying nodes/")
-		responseBody, err := conn.rqliteApiGet(api_NODES)
+		responseBody, err := conn.rqliteApiGet(context.Background(), api_NODES)
 		if err != nil {
 			return errors.New("could not determine leader from API nodes call")
 		}

--- a/cluster.go
+++ b/cluster.go
@@ -24,25 +24,11 @@ import (
 	"strings"
 )
 
-/* *****************************************************************
-
-	type: peer
-
-	this is an internal type to abstract peer info, actually just
-	represent a single hostname:port
-
- * *****************************************************************/
-
+// this is an internal type to abstract peer info, actually just
+// represent a single hostname:port
 type peer string
 
-/* *****************************************************************
-
-  type: rqliteCluster
-
-	internal type that abstracts the full cluster state (leader, peers)
-
- * *****************************************************************/
-
+// internal type that abstracts the full cluster state (leader, peers)
 type rqliteCluster struct {
 	leader     peer
 	otherPeers []peer
@@ -51,37 +37,23 @@ type rqliteCluster struct {
 	conn     *Connection
 }
 
-/* *****************************************************************
-
-  method: rqliteCluster.PeerList()
-
-	in the api calls, we'll want to try the leader first, then the other
-	peers.  to make looping easy, this function returns a list of peers
-	in the order the try them: leader, other peer, other peer, etc.
-	since the peer list might change only during updateClusterInfo(),
-	we keep it cached
-
- * *****************************************************************/
-
+// In the api calls, we'll want to try the leader first, then the other
+// peers. To make looping easy, this function returns a list of peers
+// in the order the try them: leader, other peer, other peer, etc.
+// Since the peer list might change only during updateClusterInfo(),
+// we keep it cached
 func (rc *rqliteCluster) PeerList() []peer {
 	return rc.peerList
 }
 
-/* *****************************************************************
+// tell it what peer to talk to and what kind of API operation you're
+// making, and it will return the full URL, from start to finish.
+// e.g.:
 
-	method: Connection.assembleURL()
+// https://mary:secret2@server1.example.com:1234/db/query?transaction&level=strong
 
-	tell it what peer to talk to and what kind of API operation you're
-	making, and it will return the full URL, from start to finish.
-	e.g.:
-
-	https://mary:secret2@server1.example.com:1234/db/query?transaction&level=strong
-
-	note: this func needs to live at the Connection level because the
-	Connection holds the username, password, consistencyLevel, etc.
-
- * *****************************************************************/
-
+// note: this func needs to live at the Connection level because the
+// Connection holds the username, password, consistencyLevel, etc.
 func (conn *Connection) assembleURL(apiOp apiOperation, p peer) string {
 	var builder strings.Builder
 
@@ -135,18 +107,11 @@ func (conn *Connection) assembleURL(apiOp apiOperation, p peer) string {
 	return builder.String()
 }
 
-/* *****************************************************************
-
-	method: Connection.updateClusterInfo()
-
-	upon invocation, updateClusterInfo() completely erases and refreshes
-	the Connection's cluster info, replacing its rqliteCluster object
-	with current info.
-
-	the web heavy lifting (retrying, etc.) is done in rqliteApiGet()
-
- * *****************************************************************/
-
+// Upon invocation, updateClusterInfo() completely erases and refreshes
+// the Connection's cluster info, replacing its rqliteCluster object
+// with current info.
+//
+// The web heavy lifting (retrying, etc.) is done in rqliteApiGet()
 func (conn *Connection) updateClusterInfo() error {
 	trace("%s: updateClusterInfo() called", conn.ID)
 

--- a/cluster.go
+++ b/cluster.go
@@ -38,6 +38,8 @@ type rqliteCluster struct {
 	conn     *Connection
 }
 
+// PeerList lists the peers within a rqlite cluster.
+//
 // In the api calls, we'll want to try the leader first, then the other
 // peers. To make looping easy, this function returns a list of peers
 // in the order the try them: leader, other peer, other peer, etc.
@@ -58,7 +60,7 @@ func (rc *rqliteCluster) PeerList() []peer {
 func (conn *Connection) assembleURL(apiOp apiOperation, p peer) string {
 	var builder strings.Builder
 
-	if conn.wantsHTTPS == true {
+	if conn.wantsHTTPS {
 		builder.WriteString("https")
 	} else {
 		builder.WriteString("http")
@@ -202,9 +204,8 @@ func (conn *Connection) updateClusterInfo() error {
 	if rc.leader != "" {
 		rc.peerList = append(rc.peerList, rc.leader)
 	}
-	for _, p := range rc.otherPeers {
-		rc.peerList = append(rc.peerList, p)
-	}
+
+	rc.peerList = append(rc.peerList, rc.otherPeers...)
 
 	// dump to trace
 	trace("%s: here is my cluster config:", conn.ID)

--- a/cluster_test.go
+++ b/cluster_test.go
@@ -2,38 +2,26 @@ package gorqlite_test
 
 import (
 	"testing"
-
-	"github.com/rqlite/gorqlite"
 )
 
-func TestInitCluster(t *testing.T) {
-	// gorqlite.TraceOn(os.Stderr)
-	t.Logf("trying Open: %s\n", testUrl())
-	conn, err := gorqlite.Open(testUrl())
+func TestLeader(t *testing.T) {
+	leaders, err := globalConnection.Leader()
 	if err != nil {
-		t.Logf("--> FAILED")
-		t.Fatal(err)
+		t.Errorf("failed to get leader: %v", err.Error())
 	}
 
-	l, err := conn.Leader()
+	if len(leaders) < 1 {
+		t.Errorf("expected leaders to be at least 1, got %d", len(leaders))
+	}
+}
+
+func TestPeers(t *testing.T) {
+	peers, err := globalConnection.Peers()
 	if err != nil {
-		t.Logf("--> FAILED")
-		t.Fail()
+		t.Errorf("failed to get peers: %v", err.Error())
 	}
 
-	if len(l) < 1 {
-		t.Logf("--> FAILED")
-		t.Fail()
-	}
-
-	p, err := conn.Peers()
-	if err != nil {
-		t.Logf("--> FAILED")
-		t.Fail()
-	}
-
-	if len(p) < 1 {
-		t.Logf("--> FAILED")
-		t.Fail()
+	if len(peers) < 1 {
+		t.Errorf("expected peers to be at least 1, got %d", len(peers))
 	}
 }

--- a/cluster_test.go
+++ b/cluster_test.go
@@ -1,14 +1,15 @@
-package gorqlite
+package gorqlite_test
 
 import (
-	"os"
 	"testing"
+
+	"github.com/rqlite/gorqlite"
 )
 
 func TestInitCluster(t *testing.T) {
-	TraceOn(os.Stderr)
+	// gorqlite.TraceOn(os.Stderr)
 	t.Logf("trying Open: %s\n", testUrl())
-	conn, err := Open(testUrl())
+	conn, err := gorqlite.Open(testUrl())
 	if err != nil {
 		t.Logf("--> FAILED")
 		t.Fatal(err)

--- a/conn.go
+++ b/conn.go
@@ -25,7 +25,7 @@ import (
 const defaultTimeout = 10
 
 var (
-	errClosed = errors.New("gorqlite: connection is closed")
+	ErrClosed = errors.New("gorqlite: connection is closed")
 	traceOut  io.Writer
 )
 
@@ -98,7 +98,7 @@ func (conn *Connection) Close() {
 
 func (conn *Connection) ConsistencyLevel() (string, error) {
 	if conn.hasBeenClosed {
-		return "", errClosed
+		return "", ErrClosed
 	}
 	return consistencyLevelNames[conn.consistencyLevel], nil
 }
@@ -111,7 +111,7 @@ func (conn *Connection) ConsistencyLevel() (string, error) {
 
 func (conn *Connection) Leader() (string, error) {
 	if conn.hasBeenClosed {
-		return "", errClosed
+		return "", ErrClosed
 	}
 	trace("%s: Leader(), calling updateClusterInfo()", conn.ID)
 	err := conn.updateClusterInfo()
@@ -133,7 +133,7 @@ func (conn *Connection) Leader() (string, error) {
 func (conn *Connection) Peers() ([]string, error) {
 	if conn.hasBeenClosed {
 		var ans []string
-		return ans, errClosed
+		return ans, ErrClosed
 	}
 	plist := make([]string, 0)
 
@@ -162,7 +162,7 @@ func (conn *Connection) Peers() ([]string, error) {
 
 func (conn *Connection) SetConsistencyLevel(levelDesired string) error {
 	if conn.hasBeenClosed {
-		return errClosed
+		return ErrClosed
 	}
 	_, ok := consistencyLevels[levelDesired]
 	if ok {
@@ -174,7 +174,7 @@ func (conn *Connection) SetConsistencyLevel(levelDesired string) error {
 
 func (conn *Connection) SetExecutionWithTransaction(state bool) error {
 	if conn.hasBeenClosed {
-		return errClosed
+		return ErrClosed
 	}
 	conn.wantsTransactions = state
 	return nil

--- a/conn.go
+++ b/conn.go
@@ -193,7 +193,7 @@ func (conn *Connection) initConnection(url string) error {
 		return errors.New("url specified is impossibly short")
 	}
 
-	if strings.HasPrefix(url, "http") == false {
+	if !strings.HasPrefix(url, "http") {
 		return errors.New("url does not start with 'http'")
 	}
 
@@ -266,7 +266,7 @@ func (conn *Connection) initConnection(url string) error {
 	}
 
 	trace("%s: parseDefaultPeer() is done:", conn.ID)
-	if conn.wantsHTTPS == true {
+	if conn.wantsHTTPS {
 		trace("%s:    %s -> %s", conn.ID, "wants https?", "yes")
 	} else {
 		trace("%s:    %s -> %s", conn.ID, "wants https?", "no")

--- a/conn.go
+++ b/conn.go
@@ -25,6 +25,7 @@ import (
 const defaultTimeout = 10
 
 var (
+	// ErrClosed indicates that client connection was closed
 	ErrClosed = errors.New("gorqlite: connection is closed")
 	traceOut  io.Writer
 )
@@ -32,7 +33,6 @@ var (
 // defaults to false.  This is used in trace() to quickly
 // return if tracing is off, so that we don't do a perhaps
 // expensive Sprintf() call only to send it to Discard
-
 var wantsTrace bool
 
 /* *****************************************************************
@@ -57,9 +57,7 @@ var wantsTrace bool
 type Connection struct {
 	cluster rqliteCluster
 
-	/*
-	  name               type                default
-	*/
+	// name           type                default
 
 	username          string           //   username or ""
 	password          string           //   username or ""
@@ -208,7 +206,6 @@ func (conn *Connection) initConnection(url string) error {
 	}
 
 	// specs say Username() is always populated even if empty
-
 	if u.User == nil {
 		conn.username = ""
 		conn.password = ""

--- a/conn.go
+++ b/conn.go
@@ -41,22 +41,19 @@ var wantsTrace bool
 
  * *****************************************************************/
 
-/*
-	The connection abstraction.	 Note that since rqlite is stateless,
-	there really is no "connection".  However, this type holds
-	information such as the current leader, peers, connection
-	string to build URLs, etc.
-
-	Connections are assigned a "connection ID" which is a pseudo-UUID
-	for connection identification in trace output only.  This helps
-	sort out what's going on if you have multiple connections going
-	at once.  It's generated using a non-standards-or-anything-else-compliant
-	function that uses crypto/rand to generate 16 random bytes.
-
-	Note that the Connection objection holds info on all peers, gathered
-	at time of Open() from the node specified.
-*/
-
+// The connection abstraction.	 Note that since rqlite is stateless,
+// there really is no "connection".  However, this type holds
+// information such as the current leader, peers, connection
+// string to build URLs, etc.
+//
+// Connections are assigned a "connection ID" which is a pseudo-UUID
+// for connection identification in trace output only.  This helps
+// sort out what's going on if you have multiple connections going
+// at once.  It's generated using a non-standards-or-anything-else-compliant
+// function that uses crypto/rand to generate 16 random bytes.
+//
+// Note that the Connection objection holds info on all peers, gathered
+// at time of Open() from the node specified.
 type Connection struct {
 	cluster rqliteCluster
 
@@ -186,41 +183,39 @@ func (conn *Connection) SetExecutionWithTransaction(state bool) error {
 
  * *****************************************************************/
 
-/*
-	initConnection takes the initial connection URL specified by
-	the user, and parses it into a peer.  This peer is assumed to
-	be the leader.  The next thing Open() does is updateClusterInfo()
-	so the truth will be revealed soon enough.
-
-	initConnection() does not talk to rqlite.  It only parses the
-	connection URL and prepares the new connection for work.
-
-	URL format:
-
-		http[s]://${USER}:${PASSWORD}@${HOSTNAME}:${PORT}/db?[OPTIONS]
-
-	Examples:
-
-		https://mary:secret2@localhost:4001/db
-		https://mary:secret2@server1.example.com:4001/db?level=none
-		https://mary:secret2@server2.example.com:4001/db?level=weak
-		https://mary:secret2@localhost:2265/db?level=strong
-
-	to use default connection to localhost:4001 with no auth:
-		http://
-		https://
-
-	guaranteed map fields - will be set to "" if not specified
-
-		field name                  default if not specified
-
-		username                    ""
-		password                    ""
-		hostname                    "localhost"
-		port                        "4001"
-		consistencyLevel            "weak"
-*/
-
+// initConnection takes the initial connection URL specified by
+// the user, and parses it into a peer.  This peer is assumed to
+// be the leader.  The next thing Open() does is updateClusterInfo()
+// so the truth will be revealed soon enough.
+//
+// initConnection() does not talk to rqlite.  It only parses the
+// connection URL and prepares the new connection for work.
+//
+// URL format:
+//
+// 	http[s]://${USER}:${PASSWORD}@${HOSTNAME}:${PORT}/db?[OPTIONS]
+//
+// Examples:
+//
+// 	https://mary:secret2@localhost:4001/db
+// 	https://mary:secret2@server1.example.com:4001/db?level=none
+// 	https://mary:secret2@server2.example.com:4001/db?level=weak
+// 	https://mary:secret2@localhost:2265/db?level=strong
+//
+// to use default connection to localhost:4001 with no auth:
+// 	http://
+// 	https://
+//
+// guaranteed map fields - will be set to "" if not specified
+//
+// 	field name                  default if not specified
+//
+// 	username                    ""
+// 	password                    ""
+// 	hostname                    "localhost"
+// 	port                        "4001"
+// 	consistencyLevel            "weak"
+//
 func (conn *Connection) initConnection(url string) error {
 	// do some sanity checks.  You know users.
 
@@ -267,12 +262,8 @@ func (conn *Connection) initConnection(url string) error {
 	}
 	conn.cluster.peerList = []peer{conn.cluster.leader}
 
-	/*
-
-		at the moment, the only allowed query is "level=" with
-		the desired consistency level
-
-	*/
+	// at the moment, the only allowed query is "level=" with
+	// the desired consistency level
 
 	// default
 	conn.consistencyLevel = cl_WEAK

--- a/conn_test.go
+++ b/conn_test.go
@@ -3,7 +3,7 @@ package gorqlite_test
 import (
 	"testing"
 
-	"github.com/rqlite/gorqlite"
+	"github.com/rqlite/gorqlite/v2"
 )
 
 func TestSetConsistencyLevel(t *testing.T) {

--- a/conn_test.go
+++ b/conn_test.go
@@ -3,7 +3,7 @@ package gorqlite_test
 import (
 	"testing"
 
-	"github.com/rqlite/gorqlite/v2"
+	"github.com/rqlite/gorqlite"
 )
 
 func TestSetConsistencyLevel(t *testing.T) {

--- a/conn_test.go
+++ b/conn_test.go
@@ -1,0 +1,51 @@
+package gorqlite_test
+
+import (
+	"testing"
+
+	"github.com/rqlite/gorqlite"
+)
+
+func TestSetConsistencyLevel(t *testing.T) {
+	conn, err := gorqlite.Open(testUrl())
+	if err != nil {
+		t.Fatalf("failed to open connection: %v", err.Error())
+	}
+
+	t.Run("Less than none", func(t *testing.T) {
+		err := conn.SetConsistencyLevel(-1)
+		if err == nil {
+			t.Errorf("expected error, got nil")
+		}
+	})
+
+	t.Run("Greater than strong", func(t *testing.T) {
+		err := conn.SetConsistencyLevel(100)
+		if err == nil {
+			t.Errorf("expected error, got nil")
+		}
+	})
+
+	t.Run("None", func(t *testing.T) {
+		err := conn.SetConsistencyLevel(gorqlite.ConsistencyLevelNone)
+		if err != nil {
+			t.Errorf("expected nil, got %v", err)
+		}
+	})
+
+	conn.Close()
+}
+
+func TestSetExecutionWithTransaction(t *testing.T) {
+	conn, err := gorqlite.Open(testUrl())
+	if err != nil {
+		t.Fatalf("failed to open connection: %v", err.Error())
+	}
+
+	err = conn.SetExecutionWithTransaction(true)
+	if err != nil {
+		t.Errorf("expected nil, got %v", err)
+	}
+
+	conn.Close()
+}

--- a/conn_test.go
+++ b/conn_test.go
@@ -31,6 +31,15 @@ func TestSetConsistencyLevel(t *testing.T) {
 		if err != nil {
 			t.Errorf("expected nil, got %v", err)
 		}
+
+		currentLevel, err := conn.ConsistencyLevel()
+		if err != nil {
+			t.Errorf("unexpected error: %s", err.Error())
+		}
+
+		if currentLevel != "none" {
+			t.Errorf("expected currentLevel to be 'none', instead got %s", currentLevel)
+		}
 	})
 
 	conn.Close()

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/rqlite/gorqlite/v2
+module github.com/rqlite/gorqlite
 
 go 1.17

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/rqlite/gorqlite
+module github.com/rqlite/gorqlite/v2
 
 go 1.17

--- a/gorqlite.go
+++ b/gorqlite.go
@@ -19,7 +19,6 @@ import (
 	"crypto/rand"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"strings"
 )
 
@@ -47,7 +46,7 @@ const (
 )
 
 func init() {
-	traceOut = ioutil.Discard
+	traceOut = io.Discard
 
 	consistencyLevelNames = make(map[consistencyLevel]string)
 	consistencyLevelNames[ConsistencyLevelNone] = "none"
@@ -127,7 +126,7 @@ func Open(connURL string) (*Connection, error) {
 // Don't put a \n in your Sprintf pattern becuase trace() adds one
 func trace(pattern string, args ...interface{}) {
 	// don't do the probably expensive Sprintf() if not needed
-	if wantsTrace == false {
+	if !wantsTrace {
 		return
 	}
 
@@ -156,5 +155,5 @@ func TraceOn(w io.Writer) {
 // info is sent to the io.Writer, unless it is TraceOn'd again.
 func TraceOff() {
 	wantsTrace = false
-	traceOut = ioutil.Discard
+	traceOut = io.Discard
 }

--- a/gorqlite.go
+++ b/gorqlite.go
@@ -1,15 +1,13 @@
-/*
-	gorqlite
-	A golang database/sql driver for rqlite, the distributed consistent sqlite.
-
-	Copyright (c)2016 andrew fabbro (andrew@fabbro.org)
-
-	See LICENSE.md for license. tl;dr: MIT. Conveniently, the same licese as rqlite.
-
-	Project home page: https://github.com/raindo308/gorqlite
-
-	Learn more about rqlite at: https://github.com/rqlite/rqlite
-*/
+// gorqlite
+// A golang database/sql driver for rqlite, the distributed consistent sqlite.
+//
+// Copyright (c)2016 andrew fabbro (andrew@fabbro.org)
+//
+// See LICENSE.md for license. tl;dr: MIT. Conveniently, the same licese as rqlite.
+//
+// Project home page: https://github.com/raindo308/gorqlite
+//
+// Learn more about rqlite at: https://github.com/rqlite/rqlite
 package gorqlite
 
 /*
@@ -76,26 +74,24 @@ func init() {
 	consistencyLevels["strong"] = cl_STRONG
 }
 
-/* *****************************************************************
-Open() creates and returns a "connection" to rqlite.
-
-Since rqlite is stateless, there is no actual connection.  Open() creates and initializes a gorqlite Connection type, which represents various config information.
-
-The URL should be in a form like this:
-
-	http://localhost:4001
-
-	http://     default, no auth, localhost:4001
-	https://    default, no auth, localhost:4001, using https
-
-	http://localhost:1234
-	http://mary:secret2@localhost:1234
-
-  https://mary:secret2@somewhere.example.com:1234
-  https://mary:secret2@somewhere.example.com // will use 4001
- * *****************************************************************/
-func Open(connURL string) (Connection, error) {
-	var conn Connection
+// Open() creates and returns a "connection" to rqlite.
+//
+// Since rqlite is stateless, there is no actual connection.  Open() creates and initializes a gorqlite Connection type, which represents various config information.
+//
+// The URL should be in a form like this:
+//
+//      http://localhost:4001
+//
+//      http://     default, no auth, localhost:4001
+//      https://    default, no auth, localhost:4001, using https
+//
+//      http://localhost:1234
+//      http://mary:secret2@localhost:1234
+//
+//      https://mary:secret2@somewhere.example.com:1234
+//      https://mary:secret2@somewhere.example.com // will use 4001
+func Open(connURL string) (*Connection, error) {
+	var conn = &Connection{}
 
 	// generate our uuid for trace
 	b := make([]byte, 16)
@@ -124,30 +120,25 @@ func Open(connURL string) (Connection, error) {
 	return conn, err
 }
 
-/* *****************************************************************
-
-	func: trace()
-
-	adds a message to the trace output
-
-	not a public function.  we (inside) can add - outside they can
-	only see.
-
-	Call trace as:     Sprintf pattern , args...
-
-	This is done so that the more expensive Sprintf() stuff is
-	done only if truly needed.  When tracing is off, calls to
-	trace() just hit a bool check and return.  If tracing is on,
-	then the Sprintfing is done at a leisurely pace because, well,
-	we're tracing.
-
-	Premature optimization is the root of all evil, so this is
-	probably sinful behavior.
-
-	Don't put a \n in your Sprintf pattern becuase trace() adds one
-
- * *****************************************************************/
-
+// func: trace()
+//
+// adds a message to the trace output
+//
+// not a public function.  we (inside) can add - outside they can
+// only see.
+//
+// Call trace as:     Sprintf pattern , args...
+//
+// This is done so that the more expensive Sprintf() stuff is
+// done only if truly needed.  When tracing is off, calls to
+// trace() just hit a bool check and return.  If tracing is on,
+// then the Sprintfing is done at a leisurely pace because, well,
+// we're tracing.
+//
+// Premature optimization is the root of all evil, so this is
+// probably sinful behavior.
+//
+// Don't put a \n in your Sprintf pattern becuase trace() adds one
 func trace(pattern string, args ...interface{}) {
 	// don't do the probably expensive Sprintf() if not needed
 	if wantsTrace == false {
@@ -164,27 +155,19 @@ func trace(pattern string, args ...interface{}) {
 	traceOut.Write([]byte(msg))
 }
 
-/*
-	TraceOn()
-
-	Turns on tracing output to the io.Writer of your choice.
-
-	Trace output is very detailed and verbose, as you might expect.
-
-	Normally, you should run with tracing off, as it makes absolutely
-	no concession to performance and is intended for debugging/dev use.
-*/
+// Turns on tracing output to the io.Writer of your choice.
+//
+// Trace output is very detailed and verbose, as you might expect.
+//
+// Normally, you should run with tracing off, as it makes absolutely
+// no concession to performance and is intended for debugging/dev use.
 func TraceOn(w io.Writer) {
 	traceOut = w
 	wantsTrace = true
 }
 
-/*
-	TraceOff()
-
-	Turns off tracing output.  Once you call TraceOff(), no further
-	info is sent to the io.Writer, unless it is TraceOn'd again.
-*/
+// Turns off tracing output.  Once you call TraceOff(), no further
+// info is sent to the io.Writer, unless it is TraceOn'd again.
 func TraceOff() {
 	wantsTrace = false
 	traceOut = ioutil.Discard

--- a/gorqlite.go
+++ b/gorqlite.go
@@ -3,7 +3,7 @@
 //
 // Copyright (c)2016 andrew fabbro (andrew@fabbro.org)
 //
-// See LICENSE.md for license. tl;dr: MIT. Conveniently, the same licese as rqlite.
+// See LICENSE.md for license. tl;dr: MIT. Conveniently, the same license as rqlite.
 //
 // Project home page: https://github.com/raindo308/gorqlite
 //
@@ -25,8 +25,13 @@ import (
 type consistencyLevel int
 
 const (
+	// ConsistencyLevelNone provides no consistency to other nodes.
 	ConsistencyLevelNone consistencyLevel = iota
+	// ConsistencyLevelWeak provides a weak consistency that guarantees the
+	// queries are sent to the leader.
 	ConsistencyLevelWeak
+	// ConsistencyLevelStrong provides a strong consistency and guarantees
+	// that queries are sent and received by other nodes.
 	ConsistencyLevelStrong
 )
 

--- a/gorqlite.go
+++ b/gorqlite.go
@@ -10,12 +10,10 @@
 // Learn more about rqlite at: https://github.com/rqlite/rqlite
 package gorqlite
 
-/*
-	this file contains package-level stuff:
-		consts
-		init()
-		Open, TraceOn(), TraceOff()
-*/
+// this file contains package-level stuff:
+//   consts
+//   init()
+//   Open, TraceOn(), TraceOff()
 
 import (
 	"crypto/rand"
@@ -25,18 +23,12 @@ import (
 	"strings"
 )
 
-/* *****************************************************************
-
-   const
-
- * *****************************************************************/
-
 type consistencyLevel int
 
 const (
-	cl_NONE consistencyLevel = iota
-	cl_WEAK
-	cl_STRONG
+	ConsistencyLevelNone consistencyLevel = iota
+	ConsistencyLevelWeak
+	ConsistencyLevelStrong
 )
 
 // used in several places, actually
@@ -54,24 +46,18 @@ const (
 	api_NODES
 )
 
-/* *****************************************************************
-
-   init()
-
- * *****************************************************************/
-
 func init() {
 	traceOut = ioutil.Discard
 
 	consistencyLevelNames = make(map[consistencyLevel]string)
-	consistencyLevelNames[cl_NONE] = "none"
-	consistencyLevelNames[cl_WEAK] = "weak"
-	consistencyLevelNames[cl_STRONG] = "strong"
+	consistencyLevelNames[ConsistencyLevelNone] = "none"
+	consistencyLevelNames[ConsistencyLevelWeak] = "weak"
+	consistencyLevelNames[ConsistencyLevelStrong] = "strong"
 
 	consistencyLevels = make(map[string]consistencyLevel)
-	consistencyLevels["none"] = cl_NONE
-	consistencyLevels["weak"] = cl_WEAK
-	consistencyLevels["strong"] = cl_STRONG
+	consistencyLevels["none"] = ConsistencyLevelNone
+	consistencyLevels["weak"] = ConsistencyLevelWeak
+	consistencyLevels["strong"] = ConsistencyLevelStrong
 }
 
 // Open() creates and returns a "connection" to rqlite.

--- a/gorqlite_test.go
+++ b/gorqlite_test.go
@@ -1,4 +1,4 @@
-package gorqlite
+package gorqlite_test
 
 import "os"
 

--- a/gorqlite_test.go
+++ b/gorqlite_test.go
@@ -1,10 +1,59 @@
 package gorqlite_test
 
-import "os"
+import (
+	"log"
+	"math/rand"
+	"os"
+	"testing"
+	"time"
 
-/*
-	No actual tests here, just utilities used by testing
-*/
+	"github.com/rqlite/gorqlite"
+)
+
+var globalConnection *gorqlite.Connection
+
+func TestMain(m *testing.M) {
+	rand.Seed(time.Now().UnixNano())
+
+	conn, err := gorqlite.Open(testUrl())
+	if err != nil {
+		log.Fatalf("opening connection: %v", err)
+	}
+
+	_, err = conn.Write([]string{
+		`CREATE TABLE IF NOT EXISTS ` + testTableName() + ` (id integer, name text)`,
+		`CREATE TABLE IF NOT EXISTS ` + testTableName() + `_full (id integer, name text, wallet real, bankrupt boolean, payload blob, ts DATETIME)`,
+	})
+	if err != nil {
+		log.Fatalf("creating table: %v", err)
+	}
+
+	globalConnection = conn
+
+	exitCode := m.Run()
+
+	_, err = conn.Write([]string{
+		`DROP TABLE IF EXISTS ` + testTableName(),
+		`DROP TABLE IF EXISTS ` + testTableName() + `_full`,
+	})
+	if err != nil {
+		log.Fatalf("deleting table: %v", err)
+	}
+
+	conn.Close()
+
+	os.Exit(exitCode)
+}
+
+const letterBytes = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
+
+func RandStringBytes(n int) string {
+	b := make([]byte, n)
+	for i := range b {
+		b[i] = letterBytes[rand.Intn(len(letterBytes))]
+	}
+	return string(b)
+}
 
 func testUrl() string {
 	url := os.Getenv("GORQLITE_TEST_URL")

--- a/gorqlite_test.go
+++ b/gorqlite_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/rqlite/gorqlite"
+	"github.com/rqlite/gorqlite/v2"
 )
 
 var globalConnection *gorqlite.Connection

--- a/gorqlite_test.go
+++ b/gorqlite_test.go
@@ -20,27 +20,14 @@ func TestMain(m *testing.M) {
 		log.Fatalf("opening connection: %v", err)
 	}
 
-	_, err = conn.Write([]string{
-		`CREATE TABLE IF NOT EXISTS ` + testTableName() + ` (id integer, name text)`,
-		`CREATE TABLE IF NOT EXISTS ` + testTableName() + `_full (id integer, name text, wallet real, bankrupt boolean, payload blob, ts DATETIME)`,
-		`CREATE TABLE IF NOT EXISTS ` + testTableName() + `_nullable (id integer, nullstring text, nullint64 integer, nullint32 integer, nullint16 integer, nullfloat64 real, nullbool integer, nulltime integer) strict`,
-	})
+	err = conn.SetConsistencyLevel(gorqlite.ConsistencyLevelStrong)
 	if err != nil {
-		log.Fatalf("creating table: %v", err)
+		log.Fatalf("setting consistency level: %v", err)
 	}
 
 	globalConnection = conn
 
 	exitCode := m.Run()
-
-	_, err = conn.Write([]string{
-		`DROP TABLE IF EXISTS ` + testTableName(),
-		`DROP TABLE IF EXISTS ` + testTableName() + `_full`,
-		`DROP TABLE IF EXISTS ` + testTableName() + `_nullable`,
-	})
-	if err != nil {
-		log.Fatalf("deleting table: %v", err)
-	}
 
 	conn.Close()
 

--- a/gorqlite_test.go
+++ b/gorqlite_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/rqlite/gorqlite/v2"
+	"github.com/rqlite/gorqlite"
 )
 
 var globalConnection *gorqlite.Connection

--- a/query.go
+++ b/query.go
@@ -429,6 +429,34 @@ func (qr *QueryResult) Scan(dest ...interface{}) error {
 			default:
 				return fmt.Errorf("invalid string col:%d type:%T val:%v", n, src, src)
 			}
+		case *bool:
+			switch src := src.(type) {
+			case int64:
+				b, err := strconv.ParseBool(strconv.FormatInt(src, 10))
+				if err != nil {
+					return err
+				}
+				*d.(*bool) = b
+			case string:
+				b, err := strconv.ParseBool(src)
+				if err != nil {
+					return err
+				}
+				*d.(*bool) = b
+			case bool:
+				*d.(*bool) = src
+			default:
+				return fmt.Errorf("invalid bool col:%d type:%T val:%v", n, src, src)
+			}
+		case *[]uint8:
+			switch src := src.(type) {
+			case []uint8:
+				*d.(*[]uint8) = src
+			case string:
+				*d.(*[]uint8) = []uint8(src)
+			default:
+				return fmt.Errorf("invalid []uint8 col:%d type:%T val:%v", n, src, src)
+			}
 		default:
 			return fmt.Errorf("unknown destination type (%T) to scan into in variable #%d", d, n)
 		}

--- a/query.go
+++ b/query.go
@@ -92,7 +92,7 @@ import (
 
 // QueryOne() is a convenience method that wraps Query() into a single-statement
 // method.
-func (conn *Connection) QueryOne(sqlStatement string) (qr QueryResult, err error) {
+func (conn *Connection) QueryOne(sqlStatement string, args ...interface{}) (qr QueryResult, err error) {
 	if conn.hasBeenClosed {
 		qr.Err = ErrClosed
 		return qr, ErrClosed
@@ -106,7 +106,7 @@ func (conn *Connection) QueryOne(sqlStatement string) (qr QueryResult, err error
 // Query() is used to perform SELECT operations in the database.
 //
 // It takes an array of SQL statements and executes them in a single transaction, returning an array of QueryResult vars.
-func (conn *Connection) Query(sqlStatements []string) (results []QueryResult, err error) {
+func (conn *Connection) Query(sqlStatements []string, args ...[]interface{}) (results []QueryResult, err error) {
 	results = make([]QueryResult, 0)
 
 	if conn.hasBeenClosed {
@@ -118,7 +118,7 @@ func (conn *Connection) Query(sqlStatements []string) (results []QueryResult, er
 	trace("%s: Query() for %d statements", conn.ID, len(sqlStatements))
 
 	// if we get an error POSTing, that's a showstopper
-	response, err := conn.rqliteApiPost(api_QUERY, sqlStatements)
+	response, err := conn.rqliteApiPost(api_QUERY, sqlStatements, args)
 	if err != nil {
 		trace("%s: rqliteApiCall() ERROR: %s", conn.ID, err.Error())
 		var errResult QueryResult

--- a/query.go
+++ b/query.go
@@ -291,7 +291,7 @@ func (conn *Connection) QueryParameterizedContext(ctx context.Context, sqlStatem
 	trace("%s: finished parsing, returning %d results", conn.ID, len(results))
 
 	if numStatementErrors > 0 {
-		return results, errors.New(fmt.Sprintf("there were %d statement errors", numStatementErrors))
+		return results, fmt.Errorf("there were %d statement errors", numStatementErrors)
 	} else {
 		return results, nil
 	}
@@ -564,8 +564,6 @@ func (qr *QueryResult) Scan(dest ...interface{}) error {
 					return err
 				}
 				*d = b
-			case bool:
-				*d = src
 			case nil:
 				trace("%s: skipping nil scan data for variable #%d (%s)", qr.conn.ID, n, qr.columns[n])
 			default:
@@ -573,7 +571,7 @@ func (qr *QueryResult) Scan(dest ...interface{}) error {
 			}
 		case *[]uint8:
 			switch src := src.(type) {
-			case []uint8:
+			case []byte:
 				*d = src
 			case string:
 				*d = []uint8(src)

--- a/query.go
+++ b/query.go
@@ -90,14 +90,12 @@ import (
 
  * *****************************************************************/
 
-/*
-QueryOne() is a convenience method that wraps Query() into a single-statement
-method.
-*/
+// QueryOne() is a convenience method that wraps Query() into a single-statement
+// method.
 func (conn *Connection) QueryOne(sqlStatement string) (qr QueryResult, err error) {
 	if conn.hasBeenClosed {
-		qr.Err = errClosed
-		return qr, errClosed
+		qr.Err = ErrClosed
+		return qr, ErrClosed
 	}
 	sqlStatements := make([]string, 0)
 	sqlStatements = append(sqlStatements, sqlStatement)
@@ -105,19 +103,17 @@ func (conn *Connection) QueryOne(sqlStatement string) (qr QueryResult, err error
 	return qra[0], err
 }
 
-/*
-Query() is used to perform SELECT operations in the database.
-
-It takes an array of SQL statements and executes them in a single transaction, returning an array of QueryResult vars.
-*/
+// Query() is used to perform SELECT operations in the database.
+//
+// It takes an array of SQL statements and executes them in a single transaction, returning an array of QueryResult vars.
 func (conn *Connection) Query(sqlStatements []string) (results []QueryResult, err error) {
 	results = make([]QueryResult, 0)
 
 	if conn.hasBeenClosed {
 		var errResult QueryResult
-		errResult.Err = errClosed
+		errResult.Err = ErrClosed
 		results = append(results, errResult)
-		return results, errClosed
+		return results, ErrClosed
 	}
 	trace("%s: Query() for %d statements", conn.ID, len(sqlStatements))
 
@@ -143,10 +139,8 @@ func (conn *Connection) Query(sqlStatements []string) (results []QueryResult, er
 		return results, err
 	}
 
-	/*
-		at this point, we have a "results" section and
-		a "time" section.  we can ignore the latter.
-	*/
+	// at this point, we have a "results" section and
+	// a "time" section.  we can ignore the latter.
 
 	resultsArray := sections["results"].([]interface{})
 	trace("%s: I have %d result(s) to parse", conn.ID, len(resultsArray))
@@ -212,17 +206,15 @@ func (conn *Connection) Query(sqlStatements []string) (results []QueryResult, er
 
  * *****************************************************************/
 
-/*
-A QueryResult type holds the results of a call to Query().  You could think of it as a rowset.
-
-So if you were to query:
-
-  SELECT id, name FROM some_table;
-
-then a QueryResult would hold any errors from that query, a list of columns and types, and the actual row values.
-
-Query() returns an array of QueryResult vars, while QueryOne() returns a single variable.
-*/
+// A QueryResult type holds the results of a call to Query().  You could think of it as a rowset.
+//
+// So if you were to query:
+//
+//   SELECT id, name FROM some_table;
+//
+// then a QueryResult would hold any errors from that query, a list of columns and types, and the actual row values.
+//
+// Query() returns an array of QueryResult vars, while QueryOne() returns a single variable.
 type QueryResult struct {
 	conn      *Connection
 	Err       error
@@ -243,9 +235,7 @@ type QueryResult struct {
 
  * *****************************************************************/
 
-/*
-Columns returns a list of the column names for this QueryResult.
-*/
+// Columns returns a list of the column names for this QueryResult.
 func (qr *QueryResult) Columns() []string {
 	return qr.columns
 }
@@ -256,14 +246,12 @@ func (qr *QueryResult) Columns() []string {
 
  * *****************************************************************/
 
-/*
-Map() returns the current row (as advanced by Next()) as a map[string]interface{}
-
-The key is a string corresponding to a column name.
-The value is the corresponding column.
-
-Note that only json values are supported, so you will need to type the interface{} accordingly.
-*/
+// Map() returns the current row (as advanced by Next()) as a map[string]interface{}
+//
+// The key is a string corresponding to a column name.
+// The value is the corresponding column.
+//
+// Note that only json values are supported, so you will need to type the interface{} accordingly.
 func (qr *QueryResult) Map() (map[string]interface{}, error) {
 	trace("%s: Map() called for row %d", qr.conn.ID, qr.rowNumber)
 	ans := make(map[string]interface{})
@@ -299,19 +287,17 @@ func (qr *QueryResult) Map() (map[string]interface{}, error) {
 
  * *****************************************************************/
 
-/*
-Next() positions the QueryResult result pointer so that Scan() or Map() is ready.
-
-You should call Next() first, but gorqlite will fix it if you call Map() or Scan() before
-the initial Next().
-
-A common idiom:
-
-	rows := conn.Write(something)
-	for rows.Next() {
-		// your Scan/Map and processing here.
-	}
-*/
+// Next() positions the QueryResult result pointer so that Scan() or Map() is ready.
+//
+// You should call Next() first, but gorqlite will fix it if you call Map() or Scan() before
+// the initial Next().
+//
+// A common idiom:
+//
+//      rows := conn.Write(something)
+//      for rows.Next() {
+//          // your Scan/Map and processing here.
+//      }
 func (qr *QueryResult) Next() bool {
 	if qr.rowNumber >= int64(len(qr.values)-1) {
 		return false
@@ -327,9 +313,7 @@ func (qr *QueryResult) Next() bool {
 
  * *****************************************************************/
 
-/*
-NumRows() returns the number of rows returned by the query.
-*/
+// NumRows() returns the number of rows returned by the query.
 func (qr *QueryResult) NumRows() int64 {
 	return int64(len(qr.values))
 }
@@ -340,9 +324,7 @@ func (qr *QueryResult) NumRows() int64 {
 
  * *****************************************************************/
 
-/*
-RowNumber() returns the current row number as Next() iterates through the result's rows.
-*/
+// RowNumber() returns the current row number as Next() iterates through the result's rows.
 func (qr *QueryResult) RowNumber() int64 {
 	return qr.rowNumber
 }
@@ -369,19 +351,17 @@ func toTime(src interface{}) (time.Time, error) {
 
  * *****************************************************************/
 
-/*
-Scan() takes a list of pointers and then updates them to reflect he current row's data.
-
-Note that only the following data types are used, and they
-are a subset of the types JSON uses:
-	string, for JSON strings
-	float64, for JSON numbers
-	int64, as a convenient extension
-	nil for JSON null
-
-booleans, JSON arrays, and JSON objects are not supported,
-since sqlite does not support them.
-*/
+// Scan() takes a list of pointers and then updates them to reflect he current row's data.
+//
+// Note that only the following data types are used, and they
+// are a subset of the types JSON uses:
+// 	string, for JSON strings
+// 	float64, for JSON numbers
+// 	int64, as a convenient extension
+// 	nil for JSON null
+//
+// booleans, JSON arrays, and JSON objects are not supported,
+// since sqlite does not support them.
 func (qr *QueryResult) Scan(dest ...interface{}) error {
 	trace("%s: Scan() called for %d vars", qr.conn.ID, len(dest))
 
@@ -463,13 +443,11 @@ func (qr *QueryResult) Scan(dest ...interface{}) error {
 
  * *****************************************************************/
 
-/*
-Types() returns an array of the column's types.
-
-Note that sqlite will repeat the type you tell it, but in many cases, it's ignored.  So you can initialize a column as CHAR(3) but it's really TEXT.  See https://www.sqlite.org/datatype3.html
-
-This info may additionally conflict with the reality that your data is being JSON encoded/decoded.
-*/
+// Types() returns an array of the column's types.
+//
+// Note that sqlite will repeat the type you tell it, but in many cases, it's ignored.  So you can initialize a column as CHAR(3) but it's really TEXT.  See https://www.sqlite.org/datatype3.html
+//
+// This info may additionally conflict with the reality that your data is being JSON encoded/decoded.
 func (qr *QueryResult) Types() []string {
 	return qr.types
 }

--- a/query.go
+++ b/query.go
@@ -580,7 +580,7 @@ func (qr *QueryResult) Scan(dest ...interface{}) error {
 			case []byte:
 				*d = src
 			case string:
-				*d = []uint8(src)
+				*d = []byte(src)
 			default:
 				return fmt.Errorf("invalid []byte col:%d type:%T val:%v", n, src, src)
 			}

--- a/query_test.go
+++ b/query_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/rqlite/gorqlite/v2"
+	"github.com/rqlite/gorqlite"
 )
 
 func TestQueryOne(t *testing.T) {

--- a/query_test.go
+++ b/query_test.go
@@ -3,9 +3,10 @@ package gorqlite_test
 import (
 	"context"
 	"fmt"
-	"github.com/rqlite/gorqlite/v2"
 	"testing"
 	"time"
+
+	"github.com/rqlite/gorqlite/v2"
 )
 
 func TestQueryOne(t *testing.T) {
@@ -243,8 +244,7 @@ func TestQueryOneParameterized(t *testing.T) {
 	t.Logf("trying WriteOne DROP")
 	_, err = globalConnection.WriteOne("DROP TABLE IF EXISTS " + testTableName())
 	if err != nil {
-		t.Logf("--> FATAL")
-		t.Fatal()
+		t.Errorf("dropping table: %s", err.Error())
 	}
 
 	// give an extra second for time diff between local and rqlite
@@ -253,106 +253,97 @@ func TestQueryOneParameterized(t *testing.T) {
 	t.Logf("trying WriteOne CREATE")
 	_, err = globalConnection.WriteOne("CREATE TABLE " + testTableName() + " (id integer, name text, ts DATETIME DEFAULT CURRENT_TIMESTAMP)")
 	if err != nil {
-		t.Logf("--> FATAL")
-		t.Fatal()
+		t.Errorf("craeting new table: %s", err.Error())
 	}
 
 	// When the Federation met the Cardassians
 	meeting := time.Date(2424, 1, 2, 17, 0, 0, 0, time.UTC)
 	met := fmt.Sprint(meeting.Unix())
 
-	t.Logf("trying Write INSERT")
-	s := make([]string, 0)
-	s = append(s, "INSERT INTO "+testTableName()+" (id, name) VALUES ( 1, 'Romulan' )")
-	s = append(s, "INSERT INTO "+testTableName()+" (id, name) VALUES ( 2, 'Vulcan' )")
-	s = append(s, "INSERT INTO "+testTableName()+" (id, name) VALUES ( 3, 'Klingon' )")
-	s = append(s, "INSERT INTO "+testTableName()+" (id, name) VALUES ( 4, 'Ferengi' )")
-	s = append(s, "INSERT INTO "+testTableName()+" (id, name, ts) VALUES ( 5, 'Cardassian',"+met+" )")
-	_, err = globalConnection.Write(s)
-	if err != nil {
-		t.Logf("--> FATAL")
-		t.Fatal()
-	}
+	t.Run("INSERT", func(t *testing.T) {
+		s := make([]string, 0)
+		s = append(s, "INSERT INTO "+testTableName()+" (id, name) VALUES ( 1, 'Romulan' )")
+		s = append(s, "INSERT INTO "+testTableName()+" (id, name) VALUES ( 2, 'Vulcan' )")
+		s = append(s, "INSERT INTO "+testTableName()+" (id, name) VALUES ( 3, 'Klingon' )")
+		s = append(s, "INSERT INTO "+testTableName()+" (id, name) VALUES ( 4, 'Ferengi' )")
+		s = append(s, "INSERT INTO "+testTableName()+" (id, name, ts) VALUES ( 5, 'Cardassian',"+met+" )")
+		_, err = globalConnection.Write(s)
+		if err != nil {
+			t.Errorf("inserting bulk queries: %s", err.Error())
+		}
+	})
 
-	t.Logf("trying QueryOneParameterized")
-	qr, err = globalConnection.QueryOneParameterized(
-		gorqlite.ParameterizedStatement{
-			Query:     fmt.Sprintf("SELECT name, ts FROM %s WHERE id > ?", testTableName()),
-			Arguments: []interface{}{3},
-		},
-	)
-	if err != nil {
-		t.Logf("--> FAILED (%s)", err.Error())
-		t.Fail()
-	}
+	t.Run("QueryOneParameterized", func(t *testing.T) {
+		qr, err = globalConnection.QueryOneParameterized(
+			gorqlite.ParameterizedStatement{
+				Query:     fmt.Sprintf("SELECT name, ts FROM %s WHERE id > ?", testTableName()),
+				Arguments: []interface{}{3},
+			},
+		)
+		if err != nil {
+			t.Errorf("executing query: %s", err.Error())
+		}
 
-	t.Logf("trying Next()")
-	na := qr.Next()
-	if na != true {
-		t.Logf("--> FAILED")
-		t.Fail()
-	}
+		na := qr.Next()
+		if na != true {
+			t.Error("next should return true, got false")
+		}
 
-	t.Logf("trying Map()")
-	r, err := qr.Map()
-	if err != nil {
-		t.Logf("--> FAILED (%s)", err.Error())
-		t.Fail()
-	}
-	if r["name"].(string) != "Ferengi" {
-		t.Logf("--> FAILED, expected 'Ferengi', got %s", r["name"].(string))
-		t.Fail()
-	}
-	if ts, ok := r["ts"]; ok {
-		if ts, ok := ts.(time.Time); ok {
-			// time should not be zero because it defaults to current utc time
-			if ts.IsZero() {
-				t.Logf("--> FAILED: time is zero")
-				t.Fail()
-			} else if ts.Before(started) {
-				t.Logf("--> FAILED: time %q is before start %q", ts, started)
-				t.Fail()
+		r, err := qr.Map()
+		if err != nil {
+			t.Errorf("map: %s", err.Error())
+		}
+		if r["name"].(string) != "Ferengi" {
+			t.Errorf("expected 'Ferengi', got %s", r["name"].(string))
+		}
+		if ts, ok := r["ts"]; ok {
+			if tss, ok := ts.(time.Time); ok {
+				// time should not be zero because it defaults to current utc time
+				if tss.IsZero() {
+					t.Error("time is zero")
+				} else if tss.Before(started) {
+					t.Errorf("time %q is before start %q", tss, started)
+				}
+			} else {
+				t.Errorf("ts is a real %T", ts)
 			}
 		} else {
-			t.Logf("--> FAILED: ts is a real %T", ts)
-			t.Fail()
+			t.Error("ts not found")
 		}
-	} else {
-		t.Logf("--> FAILED: ts not found")
-	}
 
-	t.Logf("trying Scan(), also float64->int64 in Scan()")
-	var id int64
-	var name string
-	var ts time.Time
-	err = qr.Scan(&id, &name)
-	if err == nil {
-		t.Logf("--> FAILED")
-		t.Fail()
-	}
-	err = qr.Scan(&name, &ts)
-	if err != nil {
-		t.Logf("--> FAILED (%s)", err.Error())
-		t.Fail()
-	}
-	if name != "Ferengi" {
-		t.Logf("--> FAILED, name should be 'Ferengi' but it's '%s'", name)
-		t.Fail()
-	}
-	qr.Next()
-	err = qr.Scan(&name, &ts)
-	if err != nil {
-		t.Logf("--> FAILED (%s)", err.Error())
-		t.Fail()
-	}
-	if name != "Cardassian" {
-		t.Logf("--> FAILED, name should be 'Cardassian' but it's '%s'", name)
-		t.Fail()
-	}
-	if ts != meeting {
-		t.Logf("--> FAILED, time should be %q but it's %q", meeting, ts)
-		t.Fail()
-	}
+		t.Logf("trying Scan(), also float64->int64 in Scan()")
+		var id int64
+		var name string
+		var ts time.Time
+
+		err = qr.Scan(&id, &name)
+		if err == nil {
+			t.Error("expected an error, got nil")
+		}
+
+		err = qr.Scan(&name, &ts)
+		if err != nil {
+			t.Errorf("scanning: %s", err.Error())
+		}
+
+		if name != "Ferengi" {
+			t.Errorf("name should be 'Ferengi' but it's '%s'", name)
+		}
+
+		qr.Next()
+		err = qr.Scan(&name, &ts)
+		if err != nil {
+			t.Errorf("scanning: %s", err.Error())
+		}
+
+		if name != "Cardassian" {
+			t.Errorf("name should be 'Cardassian' but it's '%s'", name)
+		}
+
+		if ts != meeting {
+			t.Errorf("time should be %q but it's %q", meeting, ts)
+		}
+	})
 
 	t.Logf("trying WriteOne DELETE FROM")
 	_, err = globalConnection.WriteOne("DELETE FROM " + testTableName() + "")
@@ -376,22 +367,19 @@ func TestScanNullableTypes(t *testing.T) {
 	s = append(s, "INSERT INTO "+testTableName()+"_nullable (id, nullstring, nullint64, nullint32, nullint16, nullfloat64, nullbool, nulltime) VALUES (2, 'Romulan', 1, 2, 3, 4.5, 1, "+met+")")
 	_, err = globalConnection.Write(s)
 	if err != nil {
-		t.Logf("--> FATAL")
-		t.Fatal()
+		t.Errorf("insert queries: %s", err.Error())
 	}
 
 	t.Logf("trying QueryOne")
 	qr, err = globalConnection.QueryOne("SELECT id, nullstring, nullint64, nullint32, nullint16, nullfloat64, nullbool, nulltime FROM " + testTableName() + "_nullable WHERE id IN (1, 2)")
 	if err != nil {
-		t.Logf("--> FAILED (%s)", err.Error())
-		t.Fail()
+		t.Errorf("query one: %s", err.Error())
 	}
 
 	t.Logf("trying Next()")
 	na := qr.Next()
 	if na != true {
-		t.Logf("--> FAILED")
-		t.Fail()
+		t.Error("expected next to be true, got false")
 	}
 
 	t.Logf("trying Scan()")
@@ -405,92 +393,75 @@ func TestScanNullableTypes(t *testing.T) {
 	var nullTime gorqlite.NullTime
 	err = qr.Scan(&id, &nullString, &nullInt64, &nullInt32, &nullInt16, &nullFloat64, &nullBool, &nullTime)
 	if err != nil {
-		t.Logf("--> FAILED (%s)", err.Error())
-		t.Fail()
+		t.Errorf("scanning: %s", err.Error())
 	}
+
 	if id != 1 {
-		t.Logf("--> FAILED, id should be 1 but it's %v", id)
-		t.Fail()
+		t.Errorf("id should be 1 but it's %v", id)
 	}
+
 	if nullString.Valid || nullString.String != "" {
-		t.Logf("--> FAILED, nullString should be invalid and unset but it's '%v' and '%v'", nullString.Valid, nullString.String)
-		t.Fail()
+		t.Errorf("nullString should be invalid and unset but it's '%v' and '%v'", nullString.Valid, nullString.String)
 	}
+
 	if nullInt64.Valid || nullInt64.Int64 != 0 {
-		t.Logf("--> FAILED, nullInt64 should be invalid and unset but it's '%v' and '%v'", nullInt64.Valid, nullInt64.Int64)
-		t.Fail()
+		t.Errorf("nullInt64 should be invalid and unset but it's '%v' and '%v'", nullInt64.Valid, nullInt64.Int64)
 	}
 	if nullInt32.Valid || nullInt32.Int32 != 0 {
-		t.Logf("--> FAILED, nullInt32 should be invalid and unset but it's '%v' and '%v'", nullInt32.Valid, nullInt32.Int32)
-		t.Fail()
+		t.Errorf("nullInt32 should be invalid and unset but it's '%v' and '%v'", nullInt32.Valid, nullInt32.Int32)
 	}
 	if nullInt16.Valid || nullInt16.Int16 != 0 {
-		t.Logf("--> FAILED, nullInt16 should be invalid and unset but it's '%v' and '%v'", nullInt16.Valid, nullInt16.Int16)
-		t.Fail()
+		t.Errorf("nullInt16 should be invalid and unset but it's '%v' and '%v'", nullInt16.Valid, nullInt16.Int16)
 	}
 	if nullFloat64.Valid || nullFloat64.Float64 != 0 {
-		t.Logf("--> FAILED, nullFloat64 should be invalid and unset but it's '%v' and '%v'", nullFloat64.Valid, nullFloat64.Float64)
-		t.Fail()
+		t.Errorf("nullFloat64 should be invalid and unset but it's '%v' and '%v'", nullFloat64.Valid, nullFloat64.Float64)
 	}
 	if nullBool.Valid || nullBool.Bool != false {
-		t.Logf("--> FAILED, nullBool should be invalid and unset but it's '%v' and '%v'", nullBool.Valid, nullBool.Bool)
-		t.Fail()
+		t.Errorf("nullBool should be invalid and unset but it's '%v' and '%v'", nullBool.Valid, nullBool.Bool)
 	}
 	if nullTime.Valid || !nullTime.Time.IsZero() {
-		t.Logf("--> FAILED, nullTime should be invalid and unset but it's '%v' and '%v'", nullTime.Valid, nullTime.Time)
-		t.Fail()
+		t.Errorf("nullTime should be invalid and unset but it's '%v' and '%v'", nullTime.Valid, nullTime.Time)
 	}
 
 	t.Logf("trying Next()")
 	qr.Next()
 	if na != true {
-		t.Logf("--> FAILED")
-		t.Fail()
+		t.Error("expected next to be true, got false")
 	}
 
 	t.Logf("trying Scan()")
 	err = qr.Scan(&id, &nullString, &nullInt64, &nullInt32, &nullInt16, &nullFloat64, &nullBool, &nullTime)
 	if err != nil {
-		t.Logf("--> FAILED (%s)", err.Error())
-		t.Fail()
+		t.Errorf("scanning: %s", err.Error())
 	}
 	if id != 2 {
-		t.Logf("--> FAILED, id should be 2 but it's %v", id)
-		t.Fail()
+		t.Errorf("id should be 2 but it's %v", id)
 	}
 	if !nullString.Valid || nullString.String != "Romulan" {
-		t.Logf("--> FAILED, nullString should be valid and set to 'Romulan' but it's '%v'", nullString.String)
-		t.Fail()
+		t.Errorf("nullString should be valid and set to 'Romulan' but it's '%v'", nullString.String)
 	}
 	if !nullInt64.Valid || nullInt64.Int64 != 1 {
-		t.Logf("--> FAILED, nullInt64 should be valid and set to 1 but it's '%v'", nullInt64.Int64)
-		t.Fail()
+		t.Errorf("nullInt64 should be valid and set to 1 but it's '%v'", nullInt64.Int64)
 	}
 	if !nullInt32.Valid || nullInt32.Int32 != 2 {
-		t.Logf("--> FAILED, nullInt32 should be valid and set to 2 but it's '%v'", nullInt32.Int32)
-		t.Fail()
+		t.Errorf("nullInt32 should be valid and set to 2 but it's '%v'", nullInt32.Int32)
 	}
 	if !nullInt16.Valid || nullInt16.Int16 != 3 {
-		t.Logf("--> FAILED, nullInt16 should be valid and set to 3 but it's '%v'", nullInt16.Int16)
-		t.Fail()
+		t.Errorf("nullInt16 should be valid and set to 3 but it's '%v'", nullInt16.Int16)
 	}
 	if !nullFloat64.Valid || nullFloat64.Float64 != 4.5 {
-		t.Logf("--> FAILED, nullFloat64 should be valid and set to 4.5 but it's '%v'", nullFloat64.Float64)
-		t.Fail()
+		t.Errorf("nullFloat64 should be valid and set to 4.5 but it's '%v'", nullFloat64.Float64)
 	}
 	if !nullBool.Valid || nullBool.Bool != true {
-		t.Logf("--> FAILED, nullBool should be valid and set to true but it's '%v'", nullBool.Bool)
-		t.Fail()
+		t.Errorf("nullBool should be valid and set to true but it's '%v'", nullBool.Bool)
 	}
 	if !nullTime.Valid || !nullTime.Time.Equal(meeting) {
-		t.Logf("--> FAILED, nullTime should be valid and set to '%v' but it's '%v'", meeting, nullTime.Time)
-		t.Fail()
+		t.Errorf("nullTime should be valid and set to '%v' but it's '%v'", meeting, nullTime.Time)
 	}
 
 	t.Logf("trying WriteOne DELETE FROM")
 	_, err = globalConnection.WriteOne("DELETE FROM " + testTableName() + "_nullable")
 	if err != nil {
-		t.Logf("--> FAILED (%s)", err.Error())
-		t.Fail()
+		t.Errorf("delete from: %s", err.Error())
 	}
 }

--- a/query_test.go
+++ b/query_test.go
@@ -32,86 +32,144 @@ func TestQueryOne(t *testing.T) {
 		}
 	}
 
-	t.Logf("trying QueryOne")
-	qr, err := globalConnection.QueryOne("SELECT name, ts, wallet, bankrupt, payload FROM " + testTableName() + "_full WHERE id > 3")
-	if err != nil {
-		t.Errorf("failed during query: %v", err.Error())
-	}
+	t.Run("Normal case", func(t *testing.T) {
+		qr, err := globalConnection.QueryOne("SELECT name, ts, wallet, bankrupt, payload FROM " + testTableName() + "_full WHERE id > 3")
+		if err != nil {
+			t.Errorf("failed during query: %v", err.Error())
+		}
 
-	if qr.NumRows() != 2 {
-		t.Errorf("expected 2 row, got %v", qr.NumRows())
-	}
+		if qr.NumRows() != 2 {
+			t.Errorf("expected 2 row, got %v", qr.NumRows())
+		}
 
-	na := qr.Next()
-	if na != true {
-		t.Errorf("expected true, got %v", na)
-	}
+		if len(qr.Columns()) != 5 {
+			t.Errorf("expected 5 columns, got %v", len(qr.Columns()))
+		}
 
-	if qr.RowNumber() != 0 {
-		t.Errorf("expected row number to be 0, got %v", qr.RowNumber())
-	}
+		if len(qr.Columns()) == 5 {
+			expect := []string{"name", "ts", "wallet", "bankrupt", "payload"}
+			for i, c := range qr.Columns() {
+				if c != expect[i] {
+					t.Errorf("expected column %v to be %v, got %v", i, expect[i], c)
+				}
+			}
+		}
 
-	t.Logf("trying Map()")
-	r, err := qr.Map()
-	if err != nil {
-		t.Errorf("failed during map: %v", err.Error())
-	}
+		if len(qr.Types()) != 5 {
+			t.Errorf("expected 5 types, got %v", len(qr.Types()))
+		}
 
-	if r["name"].(string) != "Ferengi" {
-		t.Errorf("expected Ferengi, got %v", r["name"])
-	}
-	if ts, ok := r["ts"]; ok {
-		if ts, ok := ts.(time.Time); ok {
-			// time should not be zero because it defaults to current utc time
-			if ts.IsZero() {
-				t.Errorf("time should not be zero, got zero")
-			} else if ts.Before(started) {
-				t.Errorf("time %q is before start %q", ts, started)
+		na := qr.Next()
+		if na != true {
+			t.Errorf("expected true, got %v", na)
+		}
+
+		if qr.RowNumber() != 0 {
+			t.Errorf("expected row number to be 0, got %v", qr.RowNumber())
+		}
+
+		t.Logf("trying Map()")
+		r, err := qr.Map()
+		if err != nil {
+			t.Errorf("failed during map: %v", err.Error())
+		}
+
+		if r["name"].(string) != "Ferengi" {
+			t.Errorf("expected Ferengi, got %v", r["name"])
+		}
+		if ts, ok := r["ts"]; ok {
+			if ts, ok := ts.(time.Time); ok {
+				// time should not be zero because it defaults to current utc time
+				if ts.IsZero() {
+					t.Errorf("time should not be zero, got zero")
+				} else if ts.Before(started) {
+					t.Errorf("time %q is before start %q", ts, started)
+				}
+			} else {
+				t.Errorf("ts is a real %T", ts)
 			}
 		} else {
-			t.Errorf("ts is a real %T", ts)
+			t.Logf("--> FAILED: ts not found")
 		}
-	} else {
-		t.Logf("--> FAILED: ts not found")
-	}
 
-	t.Logf("trying Scan(), also float64->int64 in Scan()")
-	var id int64
-	var name string
-	var ts time.Time
-	var wallet float64
-	var bankrupt bool
-	var payload []byte
-	err = qr.Scan(&id, &name)
-	if err == nil {
-		t.Errorf("expected an error to be returned, got nil")
-	}
+		t.Logf("trying Scan(), also float64->int64 in Scan()")
+		var id int64
+		var name string
+		var ts time.Time
+		var wallet float64
+		var bankrupt bool
+		var payload []byte
+		err = qr.Scan(&id, &name)
+		if err == nil {
+			t.Errorf("expected an error to be returned, got nil")
+		}
 
-	err = qr.Scan(&name, &ts, &wallet, &bankrupt, &payload)
-	if err != nil {
-		t.Errorf("scanning: %v", err.Error())
-	}
-	if name != "Ferengi" {
-		t.Errorf("name should be 'Ferengi' but it's '%s'", name)
-	}
+		err = qr.Scan(&name, &ts, &wallet, &bankrupt, &payload)
+		if err != nil {
+			t.Errorf("scanning: %v", err.Error())
+		}
+		if name != "Ferengi" {
+			t.Errorf("name should be 'Ferengi' but it's '%s'", name)
+		}
 
-	qr.Next()
+		qr.Next()
 
-	if qr.RowNumber() != 1 {
-		t.Errorf("expected row number to be 1, got %v", qr.RowNumber())
-	}
+		if qr.RowNumber() != 1 {
+			t.Errorf("expected row number to be 1, got %v", qr.RowNumber())
+		}
 
-	err = qr.Scan(&name, &ts, &wallet, &bankrupt, &payload)
-	if err != nil {
-		t.Errorf("scanning: %s", err.Error())
-	}
-	if name != "Cardassian" {
-		t.Errorf("expected name to be 'Cardassian', got: %s", name)
-	}
+		err = qr.Scan(&name, &ts, &wallet, &bankrupt, &payload)
+		if err != nil {
+			t.Errorf("scanning: %s", err.Error())
+		}
+		if name != "Cardassian" {
+			t.Errorf("expected name to be 'Cardassian', got: %s", name)
+		}
 
-	if ts != meeting {
-		t.Errorf("expected ts to equal meeting, got ts: %v, meeting: %v", ts, meeting)
-	}
+		if ts != meeting {
+			t.Errorf("expected ts to equal meeting, got ts: %v, meeting: %v", ts, meeting)
+		}
+
+		if qr.Next() == true {
+			t.Errorf("expected no more rows, got one")
+		}
+	})
+
+	t.Run("Invalid Query", func(t *testing.T) {
+		qr, err := globalConnection.QueryOne("INVALID QUERY")
+		if err == nil {
+			t.Errorf("expected an error to be returned, got nil")
+		}
+
+		if qr.Err == nil {
+			t.Errorf("expected an error to be returned, got nil")
+		}
+	})
+
+	t.Run("Map before next", func(t *testing.T) {
+		qr, err := globalConnection.QueryOne("SELECT name  FROM " + testTableName() + "_full WHERE id = 3")
+		if err != nil {
+			t.Errorf("failed during query: %v - %v", err.Error(), qr.Err.Error())
+		}
+
+		_, err = qr.Map()
+		if err == nil {
+			t.Errorf("expected an error to be returned, got nil")
+		}
+	})
+
+	t.Run("Scan before next", func(t *testing.T) {
+		qr, err := globalConnection.QueryOne("SELECT name FROM " + testTableName() + "_full WHERE id = 3")
+		if err != nil {
+			t.Errorf("failed during query: %v - %v", err.Error(), qr.Err.Error())
+		}
+
+		var name string
+		err = qr.Scan(&name)
+		if err == nil {
+			t.Errorf("expected an error to be returned, got nil")
+		}
+	})
 }
 
 func TestQueryOneContext(t *testing.T) {

--- a/query_test.go
+++ b/query_test.go
@@ -16,11 +16,11 @@ func TestQueryOne(t *testing.T) {
 
 	t.Logf("trying Write INSERT")
 	s := make([]string, 0)
-	s = append(s, "INSERT INTO "+testTableName()+"_full (id, name, wallet, bankrupt, payload, ts) VALUES ( 1, 'Romulan', 20000, 0, '{\"met\":\""+met+"\"}', "+fmt.Sprint(time.Now().Unix())+" )")
-	s = append(s, "INSERT INTO "+testTableName()+"_full (id, name, wallet, bankrupt, payload, ts) VALUES ( 2, 'Vulcan', 20000, 0, '{\"met\":\""+met+"\"}', "+fmt.Sprint(time.Now().Unix())+" )")
-	s = append(s, "INSERT INTO "+testTableName()+"_full (id, name, wallet, bankrupt, payload, ts) VALUES ( 3, 'Klingon', 20000, 1, '{\"met\":\""+met+"\"}', "+fmt.Sprint(time.Now().Unix())+" )")
-	s = append(s, "INSERT INTO "+testTableName()+"_full (id, name, wallet, bankrupt, payload, ts) VALUES ( 4, 'Ferengi', 20000, 0, '{\"met\":\""+met+"\"}', "+fmt.Sprint(time.Now().Unix())+" )")
-	s = append(s, "INSERT INTO "+testTableName()+"_full (id, name, wallet, bankrupt, payload, ts) VALUES ( 5, 'Cardassian', 25000, 1, '{\"met\":\""+met+"\"}', "+met+" )")
+	s = append(s, "INSERT INTO "+testTableName()+"_full (id, name, wallet, bankrupt, payload, ts) VALUES ( 1, 'Romulan', 123.456, 0, '{\"met\":\""+met+"\"}', "+fmt.Sprint(time.Now().Unix())+" )")
+	s = append(s, "INSERT INTO "+testTableName()+"_full (id, name, wallet, bankrupt, payload, ts) VALUES ( 2, 'Vulcan', 123.456, 0, '{\"met\":\""+met+"\"}', "+fmt.Sprint(time.Now().Unix())+" )")
+	s = append(s, "INSERT INTO "+testTableName()+"_full (id, name, wallet, bankrupt, payload, ts) VALUES ( 3, 'Klingon', 123.456, 1, '{\"met\":\""+met+"\"}', "+fmt.Sprint(time.Now().Unix())+" )")
+	s = append(s, "INSERT INTO "+testTableName()+"_full (id, name, wallet, bankrupt, payload, ts) VALUES ( 4, 'Ferengi', 123.456, 0, '{\"met\":\""+met+"\"}', "+fmt.Sprint(time.Now().Unix())+" )")
+	s = append(s, "INSERT INTO "+testTableName()+"_full (id, name, wallet, bankrupt, payload, ts) VALUES ( 5, 'Cardassian', 123.456, 1, '{\"met\":\""+met+"\"}', "+met+" )")
 	wResults, err := globalConnection.Write(s)
 	if err != nil {
 		t.Errorf("failed during insert: %v", err.Error())
@@ -32,7 +32,7 @@ func TestQueryOne(t *testing.T) {
 	}
 
 	t.Logf("trying QueryOne")
-	qr, err := globalConnection.QueryOne("SELECT name, ts FROM " + testTableName() + "_full WHERE id > 3")
+	qr, err := globalConnection.QueryOne("SELECT name, ts, wallet, bankrupt, payload FROM " + testTableName() + "_full WHERE id > 3")
 	if err != nil {
 		t.Errorf("failed during query: %v", err.Error())
 	}
@@ -70,12 +70,15 @@ func TestQueryOne(t *testing.T) {
 	var id int64
 	var name string
 	var ts time.Time
+	var wallet float64
+	var bankrupt bool
+	var payload []byte
 	err = qr.Scan(&id, &name)
 	if err == nil {
 		t.Errorf("expected an error to be returned, got nil")
 	}
 
-	err = qr.Scan(&name, &ts)
+	err = qr.Scan(&name, &ts, &wallet, &bankrupt, &payload)
 	if err != nil {
 		t.Errorf("scanning: %v", err.Error())
 	}
@@ -84,7 +87,7 @@ func TestQueryOne(t *testing.T) {
 	}
 
 	qr.Next()
-	err = qr.Scan(&name, &ts)
+	err = qr.Scan(&name, &ts, &wallet, &bankrupt, &payload)
 	if err != nil {
 		t.Errorf("scanning: %s", err.Error())
 	}

--- a/query_test.go
+++ b/query_test.go
@@ -1,20 +1,22 @@
-package gorqlite
+package gorqlite_test
 
 import (
 	"fmt"
 	"testing"
 	"time"
+
+	"github.com/rqlite/gorqlite"
 )
 
 func TestQueryOne(t *testing.T) {
-	var wr WriteResult
-	var qr QueryResult
-	var wResults []WriteResult
-	var qResults []QueryResult
+	var wr gorqlite.WriteResult
+	var qr gorqlite.QueryResult
+	var wResults []gorqlite.WriteResult
+	var qResults []gorqlite.QueryResult
 	var err error
 
 	t.Logf("trying Open")
-	conn, err := Open(testUrl())
+	conn, err := gorqlite.Open(testUrl())
 	if err != nil {
 		t.Logf("--> FATAL")
 		t.Fatal()

--- a/write.go
+++ b/write.go
@@ -49,7 +49,7 @@ import (
 
  * *****************************************************************/
 
-// WriteOne is a convenience method that wraps Write() into a single-statement
+// WriteOne wraps Write() into a single-statement
 // method.
 //
 // WriteOne uses context.Background() internally; to specify the context, use WriteOneContext.
@@ -58,13 +58,13 @@ func (conn *Connection) WriteOne(sqlStatement string) (wr WriteResult, err error
 	return wra[0], err
 }
 
-// WriteOneContext is a convenience method that wraps WriteContext() into a single-statement
+// WriteOneContext wraps WriteContext() into a single-statement
 func (conn *Connection) WriteOneContext(ctx context.Context, sqlStatement string) (wr WriteResult, err error) {
 	wra, err := conn.WriteContext(ctx, []string{sqlStatement})
 	return wra[0], err
 }
 
-// WriteOneParameterized is a convenience method that wraps WriteParameterized() into a single-statement method.
+// WriteOneParameterized wraps WriteParameterized() into a single-statement method.
 //
 // WriteOneParameterized uses context.Background() internally; to specify the context, use WriteOneParameterizedContext.
 func (conn *Connection) WriteOneParameterized(statement ParameterizedStatement) (wr WriteResult, err error) {
@@ -72,7 +72,7 @@ func (conn *Connection) WriteOneParameterized(statement ParameterizedStatement) 
 	return wra[0], err
 }
 
-// WriteOneParameterizedContext is a convenience method that wraps WriteParameterizedContext into
+// WriteOneParameterizedContext wraps WriteParameterizedContext into
 // a single-statement method.
 func (conn *Connection) WriteOneParameterizedContext(ctx context.Context, statement ParameterizedStatement) (wr WriteResult, err error) {
 	wra, err := conn.WriteParameterizedContext(ctx, []ParameterizedStatement{statement})

--- a/write.go
+++ b/write.go
@@ -54,15 +54,12 @@ import (
 
  * *****************************************************************/
 
-/*
-WriteOne() is a convenience method that wraps Write() into a single-statement
-method.
-*/
-
+// WriteOne() is a convenience method that wraps Write() into a single-statement
+// method.
 func (conn *Connection) WriteOne(sqlStatement string) (wr WriteResult, err error) {
 	if conn.hasBeenClosed {
-		wr.Err = errClosed
-		return wr, errClosed
+		wr.Err = ErrClosed
+		return wr, ErrClosed
 	}
 	sqlStatements := make([]string, 0)
 	sqlStatements = append(sqlStatements, sqlStatement)
@@ -72,30 +69,28 @@ func (conn *Connection) WriteOne(sqlStatement string) (wr WriteResult, err error
 
 func (conn *Connection) QueueOne(sqlStatement string) (seq int64, err error) {
 	if conn.hasBeenClosed {
-		return 0, errClosed
+		return 0, ErrClosed
 	}
 	sqlStatements := make([]string, 0)
 	sqlStatements = append(sqlStatements, sqlStatement)
 	return conn.Queue(sqlStatements)
 }
 
-/*
-Write() is used to perform DDL/DML in the database.  ALTER, CREATE, DELETE, DROP, INSERT, UPDATE, etc. all go through Write().
-
-Write() takes an array of SQL statements, and returns an equal-sized array of WriteResults, each corresponding to the SQL statement that produced it.
-
-All statements are executed as a single transaction.
-
-Write() returns an error if one is encountered during its operation.  If it's something like a call to the rqlite API, then it'll return that error.  If one statement out of several has an error, it will return a generic "there were %d statement errors" and you'll have to look at the individual statement's Err for more info.
-*/
+// Write() is used to perform DDL/DML in the database.  ALTER, CREATE, DELETE, DROP, INSERT, UPDATE, etc. all go through Write().
+//
+// Write() takes an array of SQL statements, and returns an equal-sized array of WriteResults, each corresponding to the SQL statement that produced it.
+//
+// All statements are executed as a single transaction.
+//
+// Write() returns an error if one is encountered during its operation.  If it's something like a call to the rqlite API, then it'll return that error.  If one statement out of several has an error, it will return a generic "there were %d statement errors" and you'll have to look at the individual statement's Err for more info.
 func (conn *Connection) Write(sqlStatements []string) (results []WriteResult, err error) {
 	results = make([]WriteResult, 0)
 
 	if conn.hasBeenClosed {
 		var errResult WriteResult
-		errResult.Err = errClosed
+		errResult.Err = ErrClosed
 		results = append(results, errResult)
-		return results, errClosed
+		return results, ErrClosed
 	}
 
 	trace("%s: Write() for %d statements", conn.ID, len(sqlStatements))
@@ -120,10 +115,8 @@ func (conn *Connection) Write(sqlStatements []string) (results []WriteResult, er
 		return results, err
 	}
 
-	/*
-		at this point, we have a "results" section and
-		a "time" section.  we can igore the latter.
-	*/
+	// at this point, we have a "results" section and
+	// a "time" section.  we can igore the latter.
 
 	resultsArray, ok := sections["results"].([]interface{})
 	if !ok {
@@ -182,7 +175,7 @@ func (conn *Connection) Write(sqlStatements []string) (results []WriteResult, er
 
 func (conn *Connection) Queue(sqlStatements []string) (seq int64, err error) {
 	if conn.hasBeenClosed {
-		return 0, errClosed
+		return 0, ErrClosed
 	}
 
 	trace("%s: Write() for %d statements", conn.ID, len(sqlStatements))
@@ -216,11 +209,9 @@ func (conn *Connection) Queue(sqlStatements []string) (seq int64, err error) {
 
  * *****************************************************************/
 
-/*
-A WriteResult holds the result of a single statement sent to Write().
-
-Write() returns an array of WriteResult vars, while WriteOne() returns a single WriteResult.
-*/
+// A WriteResult holds the result of a single statement sent to Write().
+//
+// Write() returns an array of WriteResult vars, while WriteOne() returns a single WriteResult.
 type WriteResult struct {
 	Err          error // don't trust the rest if this isn't nil
 	Timing       float64

--- a/write.go
+++ b/write.go
@@ -220,7 +220,7 @@ func (conn *Connection) WriteParameterizedContext(ctx context.Context, sqlStatem
 	trace("%s: finished parsing, returning %d results", conn.ID, len(results))
 
 	if numStatementErrors > 0 {
-		return results, errors.New(fmt.Sprintf("there were %d statement errors", numStatementErrors))
+		return results, fmt.Errorf("there were %d statement errors", numStatementErrors)
 	} else {
 		return results, nil
 	}

--- a/write_test.go
+++ b/write_test.go
@@ -122,7 +122,7 @@ func TestWrite(t *testing.T) {
 	results, err = conn.Write(s)
 	if err != nil {
 		t.Logf("--> FAILED")
-		t.Fail()
+		t.Fatal(err)
 	}
 
 	t.Logf("trying Write INSERT")
@@ -134,11 +134,17 @@ func TestWrite(t *testing.T) {
 	results, err = conn.Write(s)
 	if err != nil {
 		t.Logf("--> FAILED")
-		t.Fail()
+		for _, result := range results {
+			if result.Err != nil {
+				t.Error(result.Err)
+			}
+		}
+
+		t.Fatal(err)
 	}
 	if len(results) != 4 {
 		t.Logf("--> FAILED")
-		t.Fail()
+		t.Fatal("result does not equal to 4")
 	}
 
 	t.Logf("trying Write DROP")
@@ -147,6 +153,6 @@ func TestWrite(t *testing.T) {
 	results, err = conn.Write(s)
 	if err != nil {
 		t.Logf("--> FAILED")
-		t.Fail()
+		t.Fatal(err)
 	}
 }

--- a/write_test.go
+++ b/write_test.go
@@ -1,7 +1,9 @@
 package gorqlite_test
 
 import (
+	"context"
 	"testing"
+	"time"
 )
 
 // import "os"
@@ -109,6 +111,16 @@ func TestWriteOneQueued(t *testing.T) {
 			t.Errorf("seq must not be 0")
 		}
 	})
+}
+
+func TestQueueOneContext(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
+	defer cancel()
+
+	seq, err := globalConnection.QueueOneContext(ctx, "INSERT INTO "+testTableName()+" (id, name) VALUES ( ?, ? )", 120, "aaa bbb ccc")
+	if err != nil {
+		t.Errorf("failed during insert: %v - %v", err.Error(), seq)
+	}
 }
 
 func TestWrite(t *testing.T) {

--- a/write_test.go
+++ b/write_test.go
@@ -1,15 +1,19 @@
-package gorqlite
+package gorqlite_test
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/rqlite/gorqlite"
+)
 
 // import "os"
 
 func TestWriteOne(t *testing.T) {
-	var wr WriteResult
+	var wr gorqlite.WriteResult
 	var err error
 
 	t.Logf("trying Open")
-	conn, err := Open(testUrl())
+	conn, err := gorqlite.Open(testUrl())
 	if err != nil {
 		t.Logf("--> FATAL")
 		t.Fatal(err)
@@ -62,7 +66,7 @@ func TestWriteOneQueued(t *testing.T) {
 	var err error
 
 	t.Logf("trying Open")
-	conn, err := Open(testUrl())
+	conn, err := gorqlite.Open(testUrl())
 	if err != nil {
 		t.Logf("--> FATAL")
 		t.Fatal(err)
@@ -104,12 +108,12 @@ func TestWriteOneQueued(t *testing.T) {
 }
 
 func TestWrite(t *testing.T) {
-	var results []WriteResult
+	var results []gorqlite.WriteResult
 	var err error
 	var s []string
 
 	t.Logf("trying Open")
-	conn, err := Open(testUrl())
+	conn, err := gorqlite.Open(testUrl())
 	if err != nil {
 		t.Logf("--> FATAL")
 		t.Fatal(err)

--- a/write_test.go
+++ b/write_test.go
@@ -2,161 +2,144 @@ package gorqlite_test
 
 import (
 	"testing"
-
-	"github.com/rqlite/gorqlite"
 )
 
 // import "os"
 
 func TestWriteOne(t *testing.T) {
-	var wr gorqlite.WriteResult
-	var err error
+	t.Run("WriteOne CREATE", func(t *testing.T) {
+		tableName := RandStringBytes(8)
 
-	t.Logf("trying Open")
-	conn, err := gorqlite.Open(testUrl())
-	if err != nil {
-		t.Logf("--> FATAL")
-		t.Fatal(err)
-	}
+		wr, err := globalConnection.WriteOne("CREATE TABLE " + tableName + " (id integer, name text)")
+		if err != nil {
+			t.Errorf("failed during table creation: %v - %v", err.Error(), wr.Err.Error())
+		}
 
-	t.Logf("trying WriteOne DROP")
-	wr, err = conn.WriteOne("DROP TABLE IF EXISTS " + testTableName() + "")
-	if err != nil {
-		t.Logf("--> FAILED")
-		t.Fail()
-	}
+		if err == nil && wr.Err != nil {
+			t.Errorf("wr.Err must be nil if err is nil: %v", wr.Err.Error())
+		}
+	})
 
-	t.Logf("trying WriteOne CTHULHU (should fail, bad SQL)")
-	wr, err = conn.WriteOne("CTHULHU")
-	if err == nil {
-		t.Logf("--> FAILED")
-		t.Fail()
-	}
+	t.Run("WriteOne DROP", func(t *testing.T) {
+		tableName := RandStringBytes(8)
 
-	t.Logf("trying WriteOne CREATE")
-	wr, err = conn.WriteOne("CREATE TABLE " + testTableName() + " (id integer, name text)")
-	if err != nil {
-		t.Logf("--> FAILED")
-		t.Fail()
-	}
+		wr, err := globalConnection.WriteOne("DROP TABLE IF EXISTS " + tableName + "")
+		if err != nil {
+			t.Errorf("failed during table deletion: %v - %v", err.Error(), wr.Err)
+		}
 
-	t.Logf("trying WriteOne INSERT")
-	wr, err = conn.WriteOne("INSERT INTO " + testTableName() + " (id, name) VALUES ( 1, 'aaa bbb ccc' )")
-	if err != nil {
-		t.Logf("--> FAILED")
-		t.Fail()
-	}
+		if err == nil && wr.Err != nil {
+			t.Errorf("wr.Err must be nil if err is nil: %v", wr.Err.Error())
+		}
+	})
 
-	t.Logf("checking WriteOne RowsAffected")
-	if wr.RowsAffected != 1 {
-		t.Logf("--> FAILED")
-		t.Fail()
-	}
+	t.Run("WriteOne CTHULHU (should fail, bad SQL)", func(t *testing.T) {
+		_, err := globalConnection.WriteOne("CTHULHU")
+		if err == nil {
+			t.Errorf("err must not be nil")
+		}
+	})
 
-	t.Logf("trying WriteOne DROP")
-	wr, err = conn.WriteOne("DROP TABLE IF EXISTS " + testTableName() + "")
-	if err != nil {
-		t.Logf("--> FAILED")
-		t.Fail()
-	}
+	t.Run("WriteOne INSERT", func(t *testing.T) {
+		wr, err := globalConnection.WriteOne("INSERT INTO " + testTableName() + " (id, name) VALUES ( 1, 'aaa bbb ccc' )")
+		if err != nil {
+			t.Errorf("failed during insert: %v - %v", err.Error(), wr.Err.Error())
+		}
+
+		if err == nil && wr.Err != nil {
+			t.Errorf("wr.Err must be nil if err is nil: %v", wr.Err.Error())
+		}
+
+		if wr.RowsAffected != 1 {
+			t.Errorf("wr.RowsAffected must be 1")
+		}
+	})
+
+	t.Run("WriteOne INSERT parameterized", func(t *testing.T) {
+		wr, err := globalConnection.WriteOne("INSERT INTO "+testTableName()+" (id, name) VALUES ( ?, ? )", 2, "aaa bbb ccc")
+		if err != nil {
+			t.Errorf("failed during insert: %v - %v", err.Error(), wr.Err.Error())
+		}
+
+		if err == nil && wr.Err != nil {
+			t.Errorf("wr.Err must be nil if err is nil: %v", wr.Err.Error())
+		}
+
+		if wr.RowsAffected != 1 {
+			t.Errorf("wr.RowsAffected must be 1")
+		}
+	})
 }
 
 func TestWriteOneQueued(t *testing.T) {
-	var seq int64
-	var err error
+	t.Run("QueueOne DROP", func(t *testing.T) {
+		tableName := RandStringBytes(8)
+		seq, err := globalConnection.QueueOne("DROP TABLE IF EXISTS " + tableName)
+		if err != nil {
+			t.Errorf("failed during table deletion: %v - %v", err.Error(), seq)
+		}
+	})
 
-	t.Logf("trying Open")
-	conn, err := gorqlite.Open(testUrl())
-	if err != nil {
-		t.Logf("--> FATAL")
-		t.Fatal(err)
-	}
+	t.Run("QueueOne CREATE", func(t *testing.T) {
+		tableName := RandStringBytes(8)
+		seq, err := globalConnection.QueueOne("CREATE TABLE " + tableName + " (id integer, name text)")
+		if err != nil {
+			t.Errorf("failed during table creation: %v - %v", err.Error(), seq)
+		}
+	})
 
-	t.Logf("trying QueueOne DROP")
-	seq, err = conn.QueueOne("DROP TABLE IF EXISTS " + testTableName() + "")
-	if err != nil {
-		t.Logf("--> FAILED")
-		t.Fail()
-	}
+	t.Run("QueueOne INSERT", func(t *testing.T) {
+		seq, err := globalConnection.QueueOne("INSERT INTO " + testTableName() + " (id, name) VALUES ( 10, 'aaa bbb ccc' )")
+		if err != nil {
+			t.Errorf("failed during insert: %v - %v", err.Error(), seq)
+		}
 
-	t.Logf("trying QueueOne CREATE")
-	seq, err = conn.QueueOne("CREATE TABLE " + testTableName() + " (id integer, name text)")
-	if err != nil {
-		t.Logf("--> FAILED")
-		t.Fail()
-	}
+		if seq == 0 {
+			t.Errorf("seq must not be 0")
+		}
+	})
 
-	t.Logf("trying QueueOne INSERT")
-	seq, err = conn.QueueOne("INSERT INTO " + testTableName() + " (id, name) VALUES ( 1, 'aaa bbb ccc' )")
-	if err != nil {
-		t.Logf("--> FAILED")
-		t.Fail()
-	}
+	t.Run("QueueOne INSERT parameterized", func(t *testing.T) {
+		seq, err := globalConnection.QueueOne("INSERT INTO "+testTableName()+" (id, name) VALUES ( ?, ? )", 11, "aaa bbb ccc")
+		if err != nil {
+			t.Errorf("failed during insert: %v - %v", err.Error(), seq)
+		}
 
-	t.Logf("checking QueueOne sequence ID")
-	if seq == 0 {
-		t.Logf("--> FAILED")
-		t.Fail()
-	}
-
-	t.Logf("trying QueueOne DROP")
-	seq, err = conn.QueueOne("DROP TABLE IF EXISTS " + testTableName() + "")
-	if err != nil {
-		t.Logf("--> FAILED")
-		t.Fail()
-	}
+		if seq == 0 {
+			t.Errorf("seq must not be 0")
+		}
+	})
 }
 
 func TestWrite(t *testing.T) {
-	var results []gorqlite.WriteResult
-	var err error
-	var s []string
+	t.Run("Write DROP & CREATE", func(t *testing.T) {
+		tableName := RandStringBytes(8)
+		s := make([]string, 0)
+		s = append(s, "DROP TABLE IF EXISTS "+tableName)
+		s = append(s, "CREATE TABLE "+tableName+" (id integer, name text)")
+		results, err := globalConnection.Write(s)
+		if err != nil {
+			t.Errorf("failed during table creation: %v - %v", err.Error(), results[0].Err.Error())
+		}
+	})
 
-	t.Logf("trying Open")
-	conn, err := gorqlite.Open(testUrl())
-	if err != nil {
-		t.Logf("--> FATAL")
-		t.Fatal(err)
-	}
-
-	t.Logf("trying Write DROP & CREATE")
-	s = make([]string, 0)
-	s = append(s, "DROP TABLE IF EXISTS "+testTableName()+"")
-	s = append(s, "CREATE TABLE "+testTableName()+" (id integer, name text)")
-	results, err = conn.Write(s)
-	if err != nil {
-		t.Logf("--> FAILED")
-		t.Fatal(err)
-	}
-
-	t.Logf("trying Write INSERT")
-	s = make([]string, 0)
-	s = append(s, "INSERT INTO "+testTableName()+" (id, name) VALUES ( 1, 'aaa bbb ccc' )")
-	s = append(s, "INSERT INTO "+testTableName()+" (id, name) VALUES ( 2, 'ddd eee fff' )")
-	s = append(s, "INSERT INTO "+testTableName()+" (id, name) VALUES ( 3, 'ggg hhh iii' )")
-	s = append(s, "INSERT INTO "+testTableName()+" (id, name) VALUES ( 4, 'jjj kkk lll' )")
-	results, err = conn.Write(s)
-	if err != nil {
-		t.Logf("--> FAILED")
-		for _, result := range results {
-			if result.Err != nil {
-				t.Error(result.Err)
+	t.Run("Write INSERT", func(t *testing.T) {
+		s := make([]string, 0)
+		s = append(s, "INSERT INTO "+testTableName()+" (id, name) VALUES ( 21, 'aaa bbb ccc' )")
+		s = append(s, "INSERT INTO "+testTableName()+" (id, name) VALUES ( 22, 'ddd eee fff' )")
+		s = append(s, "INSERT INTO "+testTableName()+" (id, name) VALUES ( 23, 'ggg hhh iii' )")
+		s = append(s, "INSERT INTO "+testTableName()+" (id, name) VALUES ( 24, 'jjj kkk lll' )")
+		results, err := globalConnection.Write(s)
+		if err != nil {
+			for _, result := range results {
+				if result.Err != nil {
+					t.Errorf("result error: %v", result.Err)
+				}
 			}
 		}
 
-		t.Fatal(err)
-	}
-	if len(results) != 4 {
-		t.Logf("--> FAILED")
-		t.Fatal("result does not equal to 4")
-	}
-
-	t.Logf("trying Write DROP")
-	s = make([]string, 0)
-	s = append(s, "DROP TABLE IF EXISTS "+testTableName()+"")
-	results, err = conn.Write(s)
-	if err != nil {
-		t.Logf("--> FAILED")
-		t.Fatal(err)
-	}
+		if len(results) != 4 {
+			t.Errorf("expected results to be length of 4, got: %d", len(results))
+		}
+	})
 }

--- a/write_test.go
+++ b/write_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/rqlite/gorqlite/v2"
+	"github.com/rqlite/gorqlite"
 )
 
 func TestWriteOne(t *testing.T) {


### PR DESCRIPTION
Sorry for such a big git diff. But anyway, these are the changes that I made:
1. `gorqlite.Open()` now returns a pointer of `Connection`, this may break some users' experience. But it's only a pointer away. Every functionality are the same.
2. Addition of `QueryContext`, `QueryOneContext`, `QueueContext`, `QueueOneContext`, `WriteContext`, and `WriteOneContext` method.
  - Update 2022-09-18: Additional `QueryOneParameterizedContext`, `QueryParameterizedContext`, `WriteOneParameterizedContext`, `WriteParameterizedContext`, `QueueOneParameterizedContext`, and `QueueParameterizedContext` based on #26.
4. Comment-style from `/* */` to `//` to comply with how `go doc` generates its' documentation. So, every documented code will looks good on https://pkg.go.dev/github.com/rqlite/gorqlite
5. `errClosed = errors.New("gorqlite: connection is closed")` is now exported as `ErrClosed`, so users can do:
   ```go
    func main() {
      qr, err := conn.QueryContext(ctx, "some query...")
      if err != nil {
        if errors.Is(err, gorqlite.ErrClosed) {
          // do a retry because connection is closed
        }
      }
    }
   ```
6. (Removed, handled by #26) ~~Parameterized query is now supported, and it doesn't break the current API.~~
    <details>
    <summary>Old code spoiler</summary>

      ```go
      func main() {
        rows, err := conn.QueryContext(ctx, "SELECT name FROM table WHERE id = ?", 12)
        // do things...

        // and this also works
        secondRows, err := conn.QueryContext(ctx, "SELECT name FROM table WHERE id = 12")

        // also with Write() and Queue() methods (and their similar methods)
        _, err = conn.WriteContext(ctx, "INSERT INTO table (id, name) VALUES (?, ?)", 12, "James")

        _, err = conn.QueueContext(ctx, "INSERT INTO table (id, name) VALUES (?, ?)", 12, "James")
      }
    ```
    </details>
8. Support for scanning `bool` and `[]bytes` (handle `[]bytes` only, `bool` is handled by #26)
9. Exported consistency levels to constants `ConsistencyLevelNone`, `ConsistencyLevelWeak`, `ConsistencyLevelStrong`. Users don't have to open up documentation ever again for this one.
10. Rewritten tests to have better and consistent behavior