### PR TITLE
Add support for parameterized statements and nullable types

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,16 +141,45 @@ gorqlite.TraceOff()
 wr, err := conn.WriteParameterized(
 	[]gorqlite.ParameterizedStatement{
 		{
-			Query:     "INSERT INTO secret_agents(id, name, secret) VALUES(?, ?, ?)", 
-			Arguments: []interface{}{7, "James Bond", []byte{0x42}}
-		}
-	}
+			Query:     "INSERT INTO secret_agents(id, name, secret) VALUES(?, ?, ?)",
+			Arguments: []interface{}{7, "James Bond", []byte{0x42}},
+		},
+	},
 )
+seq, err := conn.QueueParameterized(
+	[]gorqlite.ParameterizedStatement{
+		{
+			Query:     "INSERT INTO secret_agents(id, name, secret) VALUES(?, ?, ?)",
+			Arguments: []interface{}{7, "James Bond", []byte{0x42}},
+		},
+	},
+)
+qr, err := conn.QueryParameterized(
+	[]gorqlite.ParameterizedStatement{
+		{
+			Query:     "SELECT id, name from secret_agents where id > ?",
+			Arguments: []interface{}{3},
+		},
+	},
+)
+
 // alternatively
 wr, err := conn.WriteOneParameterized(
 	gorqlite.ParameterizedStatement{
 		Query:     "INSERT INTO secret_agents(id, name, secret) VALUES(?, ?, ?)",
 		Arguments: []interface{}{7, "James Bond", []byte{0x42}},
+	},
+)
+seq, err := conn.QueueOneParameterized(
+	gorqlite.ParameterizedStatement{
+		Query:     "INSERT INTO secret_agents(id, name, secret) VALUES(?, ?, ?)",
+		Arguments: []interface{}{7, "James Bond", []byte{0x42}},
+	},
+)
+qr, err := conn.QueryOneParameterized(
+	gorqlite.ParameterizedStatement{
+		Query:     "SELECT id, name from secret_agents where id > ?",
+		Arguments: []interface{}{3},
 	},
 )
 

--- a/README.md
+++ b/README.md
@@ -183,6 +183,19 @@ qr, err := conn.QueryOneParameterized(
 	},
 )
 
+// using nullable types
+var id int64
+var name gorqlite.NullString
+rows, err := conn.QueryOne("select id, name from secret_agents where id > 500")
+for rows.Next() {
+	err := rows.Scan(&id, &name)
+}
+if name.Valid {
+	// use name.String
+} else {
+	// NULL value
+}
+
 ```
 
 ### Queued Writes

--- a/README.md
+++ b/README.md
@@ -136,6 +136,24 @@ gorqlite.TraceOn(os.Stderr)
 
 // turn off
 gorqlite.TraceOff()
+
+// using parameterized statements
+wr, err := conn.WriteParameterized(
+	[]gorqlite.ParameterizedStatement{
+		{
+			Query:     "INSERT INTO secret_agents(id, name, secret) VALUES(?, ?, ?)", 
+			Arguments: []interface{}{7, "James Bond", []byte{0x42}}
+		}
+	}
+)
+// alternatively
+wr, err := conn.WriteOneParameterized(
+	gorqlite.ParameterizedStatement{
+		Query:     "INSERT INTO secret_agents(id, name, secret) VALUES(?, ?, ?)",
+		Arguments: []interface{}{7, "James Bond", []byte{0x42}},
+	},
+)
+
 ```
 
 ### Queued Writes

--- a/query.go
+++ b/query.go
@@ -8,6 +8,48 @@ import (
 	"time"
 )
 
+// NullString represents a string that may be null.
+type NullString struct {
+	String string
+	Valid  bool // Valid is true if String is not NULL
+}
+
+// NullInt64 represents an int64 that may be null.
+type NullInt64 struct {
+	Int64 int64
+	Valid bool // Valid is true if Int64 is not NULL
+}
+
+// NullInt32 represents an int32 that may be null.
+type NullInt32 struct {
+	Int32 int32
+	Valid bool // Valid is true if Int32 is not NULL
+}
+
+// NullInt16 represents an int16 that may be null.
+type NullInt16 struct {
+	Int16 int16
+	Valid bool // Valid is true if Int16 is not NULL
+}
+
+// NullFloat64 represents a float64 that may be null.
+type NullFloat64 struct {
+	Float64 float64
+	Valid   bool // Valid is true if Float64 is not NULL
+}
+
+// NullBool represents a bool that may be null.
+type NullBool struct {
+	Bool  bool
+	Valid bool // Valid is true if Bool is not NULL
+}
+
+// NullTime represents a time.Time that may be null.
+type NullTime struct {
+	Time  time.Time
+	Valid bool // Valid is true if Time is not NULL
+}
+
 /* *****************************************************************
 
    method: Connection.Query()
@@ -91,8 +133,7 @@ import (
  * *****************************************************************/
 
 /*
-QueryOne() is a convenience method that wraps Query() into a single-statement
-method.
+QueryOne() is a convenience method that wraps Query() into a single-statement method.
 */
 func (conn *Connection) QueryOne(sqlStatement string) (qr QueryResult, err error) {
 	if conn.hasBeenClosed {
@@ -106,11 +147,36 @@ func (conn *Connection) QueryOne(sqlStatement string) (qr QueryResult, err error
 }
 
 /*
-Query() is used to perform SELECT operations in the database.
+QueryOneParameterized() is a convenience method that wraps QueryParameterized() into a single-statement method.
+*/
+func (conn *Connection) QueryOneParameterized(statement ParameterizedStatement) (qr QueryResult, err error) {
+	if conn.hasBeenClosed {
+		qr.Err = errClosed
+		return qr, errClosed
+	}
+	qra, err := conn.QueryParameterized([]ParameterizedStatement{statement})
+	return qra[0], err
+}
 
-It takes an array of SQL statements and executes them in a single transaction, returning an array of QueryResult vars.
+/*
+Query() is a convenience method that wraps QueryParameterized() into a single-statement method without parameters.
 */
 func (conn *Connection) Query(sqlStatements []string) (results []QueryResult, err error) {
+	parameterizedStatements := make([]ParameterizedStatement, 0, len(sqlStatements))
+	for _, sqlStatement := range sqlStatements {
+		parameterizedStatements = append(parameterizedStatements, ParameterizedStatement{
+			Query: sqlStatement,
+		})
+	}
+	return conn.QueryParameterized(parameterizedStatements)
+}
+
+/*
+QueryParameterized() is used to perform SELECT operations in the database.
+
+It takes an array of parameterized SQL statements and executes them in a single transaction, returning an array of QueryResult vars.
+*/
+func (conn *Connection) QueryParameterized(sqlStatements []ParameterizedStatement) (results []QueryResult, err error) {
 	results = make([]QueryResult, 0)
 
 	if conn.hasBeenClosed {
@@ -390,17 +456,13 @@ func (qr *QueryResult) Scan(dest ...interface{}) error {
 	}
 
 	if len(dest) != len(qr.columns) {
-		return errors.New(fmt.Sprintf("expected %d columns but got %d vars\n", len(qr.columns), len(dest)))
+		return fmt.Errorf("expected %d columns but got %d vars", len(qr.columns), len(dest))
 	}
 
 	thisRowValues := qr.values[qr.rowNumber].([]interface{})
 	for n, d := range dest {
 		src := thisRowValues[n]
-		if src == nil {
-			trace("%s: skipping nil scan data for variable #%d (%s)", qr.conn.ID, n, qr.columns[n])
-			continue
-		}
-		switch d.(type) {
+		switch d := d.(type) {
 		case *time.Time:
 			if src == nil {
 				continue
@@ -409,45 +471,203 @@ func (qr *QueryResult) Scan(dest ...interface{}) error {
 			if err != nil {
 				return fmt.Errorf("%v: bad time col:(%d/%s) val:%v", err, n, qr.Columns()[n], src)
 			}
-			*d.(*time.Time) = t
+			*d = t
 		case *int:
 			switch src := src.(type) {
 			case float64:
-				*d.(*int) = int(src)
+				*d = int(src)
 			case int64:
-				*d.(*int) = int(src)
+				*d = int(src)
 			case string:
 				i, err := strconv.Atoi(src)
 				if err != nil {
 					return err
 				}
-				*d.(*int) = i
+				*d = i
+			case nil:
+				trace("%s: skipping nil scan data for variable #%d (%s)", qr.conn.ID, n, qr.columns[n])
 			default:
 				return fmt.Errorf("invalid int col:%d type:%T val:%v", n, src, src)
 			}
 		case *int64:
 			switch src := src.(type) {
 			case float64:
-				*d.(*int64) = int64(src)
+				*d = int64(src)
 			case int64:
-				*d.(*int64) = src
+				*d = src
 			case string:
 				i, err := strconv.ParseInt(src, 10, 64)
 				if err != nil {
 					return err
 				}
-				*d.(*int64) = i
+				*d = i
+			case nil:
+				trace("%s: skipping nil scan data for variable #%d (%s)", qr.conn.ID, n, qr.columns[n])
 			default:
 				return fmt.Errorf("invalid int64 col:%d type:%T val:%v", n, src, src)
 			}
 		case *float64:
-			*d.(*float64) = float64(src.(float64))
+			switch src := src.(type) {
+			case float64:
+				*d = src
+			case int64:
+				*d = float64(src)
+			case string:
+				f, err := strconv.ParseFloat(src, 64)
+				if err != nil {
+					return err
+				}
+				*d = f
+			case nil:
+				trace("%s: skipping nil scan data for variable #%d (%s)", qr.conn.ID, n, qr.columns[n])
+			default:
+				return fmt.Errorf("invalid float64 col:%d type:%T val:%v", n, src, src)
+			}
 		case *string:
 			switch src := src.(type) {
 			case string:
-				*d.(*string) = src
+				*d = src
+			case nil:
+				trace("%s: skipping nil scan data for variable #%d (%s)", qr.conn.ID, n, qr.columns[n])
 			default:
 				return fmt.Errorf("invalid string col:%d type:%T val:%v", n, src, src)
+			}
+		case *bool:
+			switch src := src.(type) {
+			case float64:
+				b, err := strconv.ParseBool(strconv.FormatFloat(src, 'g', -1, 64))
+				if err != nil {
+					return err
+				}
+				*d = b
+			case int64:
+				b, err := strconv.ParseBool(strconv.FormatInt(src, 10))
+				if err != nil {
+					return err
+				}
+				*d = b
+			case string:
+				b, err := strconv.ParseBool(src)
+				if err != nil {
+					return err
+				}
+				*d = b
+			case nil:
+				trace("%s: skipping nil scan data for variable #%d (%s)", qr.conn.ID, n, qr.columns[n])
+			default:
+				return fmt.Errorf("invalid bool col:%d type:%T val:%v", n, src, src)
+			}
+		case *NullString:
+			switch src := src.(type) {
+			case string:
+				*d = NullString{Valid: true, String: src}
+			case nil:
+				*d = NullString{Valid: false}
+			default:
+				return fmt.Errorf("invalid string col:%d type:%T val:%v", n, src, src)
+			}
+		case *NullInt64:
+			switch src := src.(type) {
+			case float64:
+				*d = NullInt64{Valid: true, Int64: int64(src)}
+			case int64:
+				*d = NullInt64{Valid: true, Int64: src}
+			case string:
+				i, err := strconv.ParseInt(src, 10, 64)
+				if err != nil {
+					return err
+				}
+				*d = NullInt64{Valid: true, Int64: i}
+			case nil:
+				*d = NullInt64{Valid: false}
+			default:
+				return fmt.Errorf("invalid int64 col:%d type:%T val:%v", n, src, src)
+			}
+		case *NullInt32:
+			switch src := src.(type) {
+			case float64:
+				*d = NullInt32{Valid: true, Int32: int32(src)}
+			case int64:
+				*d = NullInt32{Valid: true, Int32: int32(src)}
+			case string:
+				i, err := strconv.ParseInt(src, 10, 32)
+				if err != nil {
+					return err
+				}
+				*d = NullInt32{Valid: true, Int32: int32(i)}
+			case nil:
+				*d = NullInt32{Valid: false}
+			default:
+				return fmt.Errorf("invalid int32 col:%d type:%T val:%v", n, src, src)
+			}
+		case *NullInt16:
+			switch src := src.(type) {
+			case float64:
+				*d = NullInt16{Valid: true, Int16: int16(src)}
+			case int64:
+				*d = NullInt16{Valid: true, Int16: int16(src)}
+			case string:
+				i, err := strconv.ParseInt(src, 10, 16)
+				if err != nil {
+					return err
+				}
+				*d = NullInt16{Valid: true, Int16: int16(i)}
+			case nil:
+				*d = NullInt16{Valid: false}
+			default:
+				return fmt.Errorf("invalid int16 col:%d type:%T val:%v", n, src, src)
+			}
+		case *NullFloat64:
+			switch src := src.(type) {
+			case float64:
+				*d = NullFloat64{Valid: true, Float64: src}
+			case int64:
+				*d = NullFloat64{Valid: true, Float64: float64(src)}
+			case string:
+				f, err := strconv.ParseFloat(src, 64)
+				if err != nil {
+					return err
+				}
+				*d = NullFloat64{Valid: true, Float64: f}
+			case nil:
+				*d = NullFloat64{Valid: false}
+			default:
+				return fmt.Errorf("invalid float64 col:%d type:%T val:%v", n, src, src)
+			}
+		case *NullBool:
+			switch src := src.(type) {
+			case float64:
+				b, err := strconv.ParseBool(strconv.FormatFloat(src, 'g', -1, 64))
+				if err != nil {
+					return err
+				}
+				*d = NullBool{Valid: true, Bool: b}
+			case int64:
+				b, err := strconv.ParseBool(strconv.FormatInt(src, 10))
+				if err != nil {
+					return err
+				}
+				*d = NullBool{Valid: true, Bool: b}
+			case string:
+				b, err := strconv.ParseBool(src)
+				if err != nil {
+					return err
+				}
+				*d = NullBool{Valid: true, Bool: b}
+			case nil:
+				*d = NullBool{Valid: false}
+			default:
+				return fmt.Errorf("invalid bool col:%d type:%T val:%v", n, src, src)
+			}
+		case *NullTime:
+			if src == nil {
+				*d = NullTime{Valid: false}
+			} else {
+				t, err := toTime(src)
+				if err != nil {
+					return fmt.Errorf("%v: bad time col:(%d/%s) val:%v", err, n, qr.Columns()[n], src)
+				}
+				*d = NullTime{Valid: true, Time: t}
 			}
 		default:
 			return fmt.Errorf("unknown destination type (%T) to scan into in variable #%d", d, n)

--- a/query_test.go
+++ b/query_test.go
@@ -57,7 +57,7 @@ func TestQueryOne(t *testing.T) {
 	t.Logf("trying QueryOne")
 	qr, err = conn.QueryOne("SELECT name, ts FROM " + testTableName() + " WHERE id > 3")
 	if err != nil {
-		t.Logf("--> FAILED")
+		t.Logf("--> FAILED (%s)", err.Error())
 		t.Fail()
 	}
 
@@ -71,11 +71,11 @@ func TestQueryOne(t *testing.T) {
 	t.Logf("trying Map()")
 	r, err := qr.Map()
 	if err != nil {
-		t.Logf("--> FAILED")
+		t.Logf("--> FAILED (%s)", err.Error())
 		t.Fail()
 	}
 	if r["name"].(string) != "Ferengi" {
-		t.Logf("--> FAILED")
+		t.Logf("--> FAILED, expected 'Ferengi', got %s", r["name"].(string))
 		t.Fail()
 	}
 	if ts, ok := r["ts"]; ok {
@@ -96,13 +96,13 @@ func TestQueryOne(t *testing.T) {
 		t.Logf("--> FAILED: ts not found")
 	}
 
-	t.Logf("trying Scan(), also float64->int64 in Scan()")
+	t.Logf("trying Scan()")
 	var id int64
 	var name string
 	var ts time.Time
 	err = qr.Scan(&id, &name)
 	if err == nil {
-		t.Logf("--> FAILED (%s)", err.Error())
+		t.Logf("--> FAILED")
 		t.Fail()
 	}
 	err = qr.Scan(&name, &ts)
@@ -121,18 +121,18 @@ func TestQueryOne(t *testing.T) {
 		t.Fail()
 	}
 	if name != "Cardassian" {
-		t.Logf("--> FAILED")
+		t.Logf("--> FAILED, name should be 'Cardassian' but it's '%s'", name)
 		t.Fail()
 	}
 	if ts != meeting {
-		t.Logf("--> FAILED")
+		t.Logf("--> FAILED, ts should be %q but it's %q", meeting, ts)
 		t.Fail()
 	}
 
 	t.Logf("trying WriteOne DROP")
 	wr, err = conn.WriteOne("DROP TABLE IF EXISTS " + testTableName() + "")
 	if err != nil {
-		t.Logf("--> FAILED")
+		t.Logf("--> FAILED (%s)", err.Error())
 		t.Fail()
 	}
 
@@ -177,4 +177,351 @@ func TestQueryOne(t *testing.T) {
 		t.Fail()
 	}
 	_ = qResults
+}
+
+func TestQueryOneParameterized(t *testing.T) {
+	var wr WriteResult
+	var qr QueryResult
+	var wResults []WriteResult
+	var qResults []QueryResult
+	var err error
+
+	t.Logf("trying Open")
+	conn, err := Open(testUrl())
+	if err != nil {
+		t.Logf("--> FATAL")
+		t.Fatal()
+	}
+
+	t.Logf("trying WriteOne DROP")
+	wr, err = conn.WriteOne("DROP TABLE IF EXISTS " + testTableName())
+	if err != nil {
+		t.Logf("--> FATAL")
+		t.Fatal()
+	}
+
+	// give an extra second for time diff between local and rqlite
+	started := time.Now().Add(-time.Second)
+
+	t.Logf("trying WriteOne CREATE")
+	wr, err = conn.WriteOne("CREATE TABLE " + testTableName() + " (id integer, name text, ts DATETIME DEFAULT CURRENT_TIMESTAMP)")
+	if err != nil {
+		t.Logf("--> FATAL")
+		t.Fatal()
+	}
+
+	// When the Federation met the Cardassians
+	meeting := time.Date(2424, 1, 2, 17, 0, 0, 0, time.UTC)
+	met := fmt.Sprint(meeting.Unix())
+
+	t.Logf("trying Write INSERT")
+	s := make([]string, 0)
+	s = append(s, "INSERT INTO "+testTableName()+" (id, name) VALUES ( 1, 'Romulan' )")
+	s = append(s, "INSERT INTO "+testTableName()+" (id, name) VALUES ( 2, 'Vulcan' )")
+	s = append(s, "INSERT INTO "+testTableName()+" (id, name) VALUES ( 3, 'Klingon' )")
+	s = append(s, "INSERT INTO "+testTableName()+" (id, name) VALUES ( 4, 'Ferengi' )")
+	s = append(s, "INSERT INTO "+testTableName()+" (id, name, ts) VALUES ( 5, 'Cardassian',"+met+" )")
+	wResults, err = conn.Write(s)
+	if err != nil {
+		t.Logf("--> FATAL")
+		t.Fatal()
+	}
+
+	t.Logf("trying QueryOneParameterized")
+	qr, err = conn.QueryOneParameterized(
+		ParameterizedStatement{
+			Query:     fmt.Sprintf("SELECT name, ts FROM %s WHERE id > ?", testTableName()),
+			Arguments: []interface{}{3},
+		},
+	)
+	if err != nil {
+		t.Logf("--> FAILED (%s)", err.Error())
+		t.Fail()
+	}
+
+	t.Logf("trying Next()")
+	na := qr.Next()
+	if na != true {
+		t.Logf("--> FAILED")
+		t.Fail()
+	}
+
+	t.Logf("trying Map()")
+	r, err := qr.Map()
+	if err != nil {
+		t.Logf("--> FAILED (%s)", err.Error())
+		t.Fail()
+	}
+	if r["name"].(string) != "Ferengi" {
+		t.Logf("--> FAILED, expected 'Ferengi', got %s", r["name"].(string))
+		t.Fail()
+	}
+	if ts, ok := r["ts"]; ok {
+		if ts, ok := ts.(time.Time); ok {
+			// time should not be zero because it defaults to current utc time
+			if ts.IsZero() {
+				t.Logf("--> FAILED: time is zero")
+				t.Fail()
+			} else if ts.Before(started) {
+				t.Logf("--> FAILED: time %q is before start %q", ts, started)
+				t.Fail()
+			}
+		} else {
+			t.Logf("--> FAILED: ts is a real %T", ts)
+			t.Fail()
+		}
+	} else {
+		t.Logf("--> FAILED: ts not found")
+	}
+
+	t.Logf("trying Scan(), also float64->int64 in Scan()")
+	var id int64
+	var name string
+	var ts time.Time
+	err = qr.Scan(&id, &name)
+	if err == nil {
+		t.Logf("--> FAILED")
+		t.Fail()
+	}
+	err = qr.Scan(&name, &ts)
+	if err != nil {
+		t.Logf("--> FAILED (%s)", err.Error())
+		t.Fail()
+	}
+	if name != "Ferengi" {
+		t.Logf("--> FAILED, name should be 'Ferengi' but it's '%s'", name)
+		t.Fail()
+	}
+	qr.Next()
+	err = qr.Scan(&name, &ts)
+	if err != nil {
+		t.Logf("--> FAILED (%s)", err.Error())
+		t.Fail()
+	}
+	if name != "Cardassian" {
+		t.Logf("--> FAILED, name should be 'Cardassian' but it's '%s'", name)
+		t.Fail()
+	}
+	if ts != meeting {
+		t.Logf("--> FAILED, time should be %q but it's %q", meeting, ts)
+		t.Fail()
+	}
+
+	t.Logf("trying WriteOne DROP")
+	wr, err = conn.WriteOne("DROP TABLE IF EXISTS " + testTableName() + "")
+	if err != nil {
+		t.Logf("--> FAILED (%s)", err.Error())
+		t.Fail()
+	}
+
+	t.Logf("trying Close")
+	conn.Close()
+
+	t.Logf("trying WriteOne after Close")
+	wr, err = conn.WriteOne("DROP TABLE IF EXISTS " + testTableName() + "")
+	if err == nil {
+		t.Logf("--> FAILED")
+		t.Fail()
+	}
+	_ = wr
+
+	t.Logf("trying Write after Close")
+	t1 := make([]string, 0)
+	t1 = append(t1, "DROP TABLE IF EXISTS "+testTableName()+"")
+	t1 = append(t1, "DROP TABLE IF EXISTS "+testTableName()+"")
+	wResults, err = conn.Write(t1)
+	if err == nil {
+		t.Logf("--> FAILED")
+		t.Fail()
+	}
+	_ = wResults
+
+	t.Logf("trying QueryOneParameterized after Close")
+	qr, err = conn.QueryOneParameterized(
+		ParameterizedStatement{
+			Query: fmt.Sprintf("SELECT id FROM %s", testTableName()),
+		},
+	)
+	if err == nil {
+		t.Logf("--> FAILED")
+		t.Fail()
+	}
+	_ = qr
+
+	t.Logf("trying QueryParameterized after Close")
+	_, err = conn.QueryParameterized(
+		[]ParameterizedStatement{
+			{
+				Query: fmt.Sprintf("SELECT id FROM %s", testTableName()),
+			},
+			{
+				Query: fmt.Sprintf("SELECT name FROM %s", testTableName()),
+			},
+			{
+				Query: fmt.Sprintf("SELECT id, name FROM %s", testTableName()),
+			},
+		},
+	)
+	if err == nil {
+		t.Logf("--> FAILED")
+		t.Fail()
+	}
+	_ = qResults
+}
+
+func TestScanNullableTypes(t *testing.T) {
+	var qr QueryResult
+	var err error
+
+	t.Logf("trying Open")
+	conn, err := Open(testUrl())
+	if err != nil {
+		t.Logf("--> FATAL")
+		t.Fatal()
+	}
+
+	t.Logf("trying WriteOne DROP")
+	_, err = conn.WriteOne("DROP TABLE IF EXISTS " + testTableName())
+	if err != nil {
+		t.Logf("--> FATAL")
+		t.Fatal()
+	}
+
+	t.Logf("trying WriteOne CREATE")
+	_, err = conn.WriteOne("CREATE TABLE " + testTableName() + " (id integer, nullstring text, nullint64 integer, nullint32 integer, nullint16 integer, nullfloat64 real, nullbool integer, nulltime integer) strict")
+	if err != nil {
+		t.Logf("--> FATAL")
+		t.Fatal()
+	}
+
+	// When the Federation met the Cardassians
+	meeting := time.Date(2424, 1, 2, 17, 0, 0, 0, time.UTC)
+	met := fmt.Sprint(meeting.Unix())
+
+	t.Logf("trying Write INSERT")
+	s := make([]string, 0)
+	s = append(s, "INSERT INTO "+testTableName()+" (id) VALUES (1)") // other values are gonna be null
+	s = append(s, "INSERT INTO "+testTableName()+" (id, nullstring, nullint64, nullint32, nullint16, nullfloat64, nullbool, nulltime) VALUES (2, 'Romulan', 1, 2, 3, 4.5, 1, "+met+")")
+	_, err = conn.Write(s)
+	if err != nil {
+		t.Logf("--> FATAL")
+		t.Fatal()
+	}
+
+	t.Logf("trying QueryOne")
+	qr, err = conn.QueryOne("SELECT id, nullstring, nullint64, nullint32, nullint16, nullfloat64, nullbool, nulltime FROM " + testTableName() + " WHERE id IN (1, 2)")
+	if err != nil {
+		t.Logf("--> FAILED (%s)", err.Error())
+		t.Fail()
+	}
+
+	t.Logf("trying Next()")
+	na := qr.Next()
+	if na != true {
+		t.Logf("--> FAILED")
+		t.Fail()
+	}
+
+	t.Logf("trying Scan()")
+	var id int64
+	var nullString NullString
+	var nullInt64 NullInt64
+	var nullInt32 NullInt32
+	var nullInt16 NullInt16
+	var nullFloat64 NullFloat64
+	var nullBool NullBool
+	var nullTime NullTime
+	err = qr.Scan(&id, &nullString, &nullInt64, &nullInt32, &nullInt16, &nullFloat64, &nullBool, &nullTime)
+	if err != nil {
+		t.Logf("--> FAILED (%s)", err.Error())
+		t.Fail()
+	}
+	if id != 1 {
+		t.Logf("--> FAILED, id should be 1 but it's %v", id)
+		t.Fail()
+	}
+	if nullString.Valid || nullString.String != "" {
+		t.Logf("--> FAILED, nullString should be invalid and unset but it's '%v' and '%v'", nullString.Valid, nullString.String)
+		t.Fail()
+	}
+	if nullInt64.Valid || nullInt64.Int64 != 0 {
+		t.Logf("--> FAILED, nullInt64 should be invalid and unset but it's '%v' and '%v'", nullInt64.Valid, nullInt64.Int64)
+		t.Fail()
+	}
+	if nullInt32.Valid || nullInt32.Int32 != 0 {
+		t.Logf("--> FAILED, nullInt32 should be invalid and unset but it's '%v' and '%v'", nullInt32.Valid, nullInt32.Int32)
+		t.Fail()
+	}
+	if nullInt16.Valid || nullInt16.Int16 != 0 {
+		t.Logf("--> FAILED, nullInt16 should be invalid and unset but it's '%v' and '%v'", nullInt16.Valid, nullInt16.Int16)
+		t.Fail()
+	}
+	if nullFloat64.Valid || nullFloat64.Float64 != 0 {
+		t.Logf("--> FAILED, nullFloat64 should be invalid and unset but it's '%v' and '%v'", nullFloat64.Valid, nullFloat64.Float64)
+		t.Fail()
+	}
+	if nullBool.Valid || nullBool.Bool != false {
+		t.Logf("--> FAILED, nullBool should be invalid and unset but it's '%v' and '%v'", nullBool.Valid, nullBool.Bool)
+		t.Fail()
+	}
+	if nullTime.Valid || !nullTime.Time.IsZero() {
+		t.Logf("--> FAILED, nullTime should be invalid and unset but it's '%v' and '%v'", nullTime.Valid, nullTime.Time)
+		t.Fail()
+	}
+
+	t.Logf("trying Next()")
+	qr.Next()
+	if na != true {
+		t.Logf("--> FAILED")
+		t.Fail()
+	}
+
+	t.Logf("trying Scan()")
+	err = qr.Scan(&id, &nullString, &nullInt64, &nullInt32, &nullInt16, &nullFloat64, &nullBool, &nullTime)
+	if err != nil {
+		t.Logf("--> FAILED (%s)", err.Error())
+		t.Fail()
+	}
+	if id != 2 {
+		t.Logf("--> FAILED, id should be 2 but it's %v", id)
+		t.Fail()
+	}
+	if !nullString.Valid || nullString.String != "Romulan" {
+		t.Logf("--> FAILED, nullString should be valid and set to 'Romulan' but it's '%v'", nullString.String)
+		t.Fail()
+	}
+	if !nullInt64.Valid || nullInt64.Int64 != 1 {
+		t.Logf("--> FAILED, nullInt64 should be valid and set to 1 but it's '%v'", nullInt64.Int64)
+		t.Fail()
+	}
+	if !nullInt32.Valid || nullInt32.Int32 != 2 {
+		t.Logf("--> FAILED, nullInt32 should be valid and set to 2 but it's '%v'", nullInt32.Int32)
+		t.Fail()
+	}
+	if !nullInt16.Valid || nullInt16.Int16 != 3 {
+		t.Logf("--> FAILED, nullInt16 should be valid and set to 3 but it's '%v'", nullInt16.Int16)
+		t.Fail()
+	}
+	if !nullFloat64.Valid || nullFloat64.Float64 != 4.5 {
+		t.Logf("--> FAILED, nullFloat64 should be valid and set to 4.5 but it's '%v'", nullFloat64.Float64)
+		t.Fail()
+	}
+	if !nullBool.Valid || nullBool.Bool != true {
+		t.Logf("--> FAILED, nullBool should be valid and set to true but it's '%v'", nullBool.Bool)
+		t.Fail()
+	}
+	if !nullTime.Valid || !nullTime.Time.Equal(meeting) {
+		t.Logf("--> FAILED, nullTime should be valid and set to '%v' but it's '%v'", meeting, nullTime.Time)
+		t.Fail()
+	}
+
+	t.Logf("trying WriteOne DROP")
+	_, err = conn.WriteOne("DROP TABLE IF EXISTS " + testTableName() + "")
+	if err != nil {
+		t.Logf("--> FAILED (%s)", err.Error())
+		t.Fail()
+	}
+
+	t.Logf("trying Close")
+	conn.Close()
 }

--- a/write_test.go
+++ b/write_test.go
@@ -1,8 +1,9 @@
 package gorqlite
 
-import "testing"
-
-// import "os"
+import (
+	"fmt"
+	"testing"
+)
 
 func TestWriteOne(t *testing.T) {
 	var wr WriteResult
@@ -18,7 +19,7 @@ func TestWriteOne(t *testing.T) {
 	t.Logf("trying WriteOne DROP")
 	wr, err = conn.WriteOne("DROP TABLE IF EXISTS " + testTableName() + "")
 	if err != nil {
-		t.Logf("--> FAILED")
+		t.Logf("--> FAILED (%s)", err.Error())
 		t.Fail()
 	}
 
@@ -32,32 +33,32 @@ func TestWriteOne(t *testing.T) {
 	t.Logf("trying WriteOne CREATE")
 	wr, err = conn.WriteOne("CREATE TABLE " + testTableName() + " (id integer, name text)")
 	if err != nil {
-		t.Logf("--> FAILED")
+		t.Logf("--> FAILED (%s)", err.Error())
 		t.Fail()
 	}
 
 	t.Logf("trying WriteOne INSERT")
 	wr, err = conn.WriteOne("INSERT INTO " + testTableName() + " (id, name) VALUES ( 1, 'aaa bbb ccc' )")
 	if err != nil {
-		t.Logf("--> FAILED")
+		t.Logf("--> FAILED (%s)", err.Error())
 		t.Fail()
 	}
 
 	t.Logf("checking WriteOne RowsAffected")
 	if wr.RowsAffected != 1 {
-		t.Logf("--> FAILED")
+		t.Logf("--> FAILED, expected 1, got %d", wr.RowsAffected)
 		t.Fail()
 	}
 
 	t.Logf("trying WriteOne DROP")
 	wr, err = conn.WriteOne("DROP TABLE IF EXISTS " + testTableName() + "")
 	if err != nil {
-		t.Logf("--> FAILED")
+		t.Logf("--> FAILED (%s)", err.Error())
 		t.Fail()
 	}
 }
 
-func TestWriteOneQueued(t *testing.T) {
+func TestQueueOne(t *testing.T) {
 	var seq int64
 	var err error
 
@@ -71,34 +72,167 @@ func TestWriteOneQueued(t *testing.T) {
 	t.Logf("trying QueueOne DROP")
 	seq, err = conn.QueueOne("DROP TABLE IF EXISTS " + testTableName() + "")
 	if err != nil {
-		t.Logf("--> FAILED")
+		t.Logf("--> FAILED (%s)", err.Error())
 		t.Fail()
 	}
 
 	t.Logf("trying QueueOne CREATE")
 	seq, err = conn.QueueOne("CREATE TABLE " + testTableName() + " (id integer, name text)")
 	if err != nil {
-		t.Logf("--> FAILED")
+		t.Logf("--> FAILED (%s)", err.Error())
 		t.Fail()
 	}
 
 	t.Logf("trying QueueOne INSERT")
 	seq, err = conn.QueueOne("INSERT INTO " + testTableName() + " (id, name) VALUES ( 1, 'aaa bbb ccc' )")
 	if err != nil {
-		t.Logf("--> FAILED")
+		t.Logf("--> FAILED (%s)", err.Error())
 		t.Fail()
 	}
 
 	t.Logf("checking QueueOne sequence ID")
 	if seq == 0 {
-		t.Logf("--> FAILED")
+		t.Logf("--> FAILED, expected non-zero, got %d", seq)
 		t.Fail()
 	}
 
 	t.Logf("trying QueueOne DROP")
 	seq, err = conn.QueueOne("DROP TABLE IF EXISTS " + testTableName() + "")
 	if err != nil {
-		t.Logf("--> FAILED")
+		t.Logf("--> FAILED (%s)", err.Error())
+		t.Fail()
+	}
+}
+
+func TestWriteOneParameterized(t *testing.T) {
+	var wr WriteResult
+	var err error
+
+	t.Logf("trying Open")
+	conn, err := Open(testUrl())
+	if err != nil {
+		t.Logf("--> FATAL")
+		t.Fatal(err)
+	}
+
+	t.Logf("trying WriteOneParameterized DROP")
+	wr, err = conn.WriteOneParameterized(
+		ParameterizedStatement{
+			Query: fmt.Sprintf("DROP TABLE IF EXISTS %s", testTableName()),
+		},
+	)
+	if err != nil {
+		t.Logf("--> FAILED (%s)", err.Error())
+		t.Fail()
+	}
+
+	t.Logf("trying WriteOneParameterized CTHULHU (should fail, bad SQL)")
+	wr, err = conn.WriteOneParameterized(
+		ParameterizedStatement{
+			Query: "CTHULHU",
+		},
+	)
+	if err == nil {
+		t.Logf("--> FAILED, expected an error but got none")
+		t.Fail()
+	}
+
+	t.Logf("trying WriteOneParameterized CREATE")
+	wr, err = conn.WriteOneParameterized(
+		ParameterizedStatement{
+			Query: fmt.Sprintf("CREATE TABLE %s (id integer, name text)", testTableName()),
+		},
+	)
+	if err != nil {
+		t.Logf("--> FAILED (%s)", err.Error())
+		t.Fail()
+	}
+
+	t.Logf("trying WriteOneParameterized INSERT")
+	wr, err = conn.WriteOneParameterized(
+		ParameterizedStatement{
+			Query: fmt.Sprintf("INSERT INTO %s (id, name) VALUES ( 1, 'aaa bbb ccc' )", testTableName()),
+		},
+	)
+	if err != nil {
+		t.Logf("--> FAILED (%s)", err.Error())
+		t.Fail()
+	}
+
+	t.Logf("checking WriteOneParameterized RowsAffected")
+	if wr.RowsAffected != 1 {
+		t.Logf("--> FAILED, expected 1 row affected, got %d", wr.RowsAffected)
+		t.Fail()
+	}
+
+	t.Logf("trying WriteOneParameterized DROP")
+	wr, err = conn.WriteOneParameterized(
+		ParameterizedStatement{
+			Query: fmt.Sprintf("DROP TABLE IF EXISTS %s", testTableName()),
+		},
+	)
+	if err != nil {
+		t.Logf("--> FAILED (%s)", err.Error())
+		t.Fail()
+	}
+}
+
+func TestQueueOneParameterized(t *testing.T) {
+	var seq int64
+	var err error
+
+	t.Logf("trying Open")
+	conn, err := Open(testUrl())
+	if err != nil {
+		t.Logf("--> FATAL")
+		t.Fatal(err)
+	}
+
+	t.Logf("trying QueueOneParameterized DROP")
+	seq, err = conn.QueueOneParameterized(
+		ParameterizedStatement{
+			Query: fmt.Sprintf("DROP TABLE IF EXISTS %s", testTableName()),
+		},
+	)
+	if err != nil {
+		t.Logf("--> FAILED (%s)", err.Error())
+		t.Fail()
+	}
+
+	t.Logf("trying QueueOneParameterized CREATE")
+	seq, err = conn.QueueOneParameterized(
+		ParameterizedStatement{
+			Query: fmt.Sprintf("CREATE TABLE %s (id integer, name text)", testTableName()),
+		},
+	)
+	if err != nil {
+		t.Logf("--> FAILED (%s)", err.Error())
+		t.Fail()
+	}
+
+	t.Logf("trying QueueOneParameterized INSERT")
+	seq, err = conn.QueueOneParameterized(ParameterizedStatement{
+		Query: fmt.Sprintf("INSERT INTO %s (id, name) VALUES ( 1, 'aaa bbb ccc' )", testTableName()),
+	})
+	if err != nil {
+		t.Logf("--> FAILED (%s)", err.Error())
+		t.Fail()
+	}
+
+	t.Logf("checking QueueOneParameterized sequence ID")
+	if seq == 0 {
+		t.Logf("--> FAILED, expected a sequence ID, got 0")
+		t.Fail()
+	}
+
+	t.Logf("trying QueueOneParameterized DROP")
+	seq, err = conn.QueueOneParameterized(
+		ParameterizedStatement{
+			Query: fmt.Sprintf("DROP TABLE IF EXISTS %s", testTableName()),
+		},
+	)
+	if err != nil {
+		t.Logf("--> FAILED (%s)", err.Error())
 		t.Fail()
 	}
 }
@@ -121,7 +255,7 @@ func TestWrite(t *testing.T) {
 	s = append(s, "CREATE TABLE "+testTableName()+" (id integer, name text)")
 	results, err = conn.Write(s)
 	if err != nil {
-		t.Logf("--> FAILED")
+		t.Logf("--> FAILED (%s)", err.Error())
 		t.Fail()
 	}
 
@@ -133,11 +267,11 @@ func TestWrite(t *testing.T) {
 	s = append(s, "INSERT INTO "+testTableName()+" (id, name) VALUES ( 4, 'jjj kkk lll' )")
 	results, err = conn.Write(s)
 	if err != nil {
-		t.Logf("--> FAILED")
+		t.Logf("--> FAILED (%s)", err.Error())
 		t.Fail()
 	}
 	if len(results) != 4 {
-		t.Logf("--> FAILED")
+		t.Logf("--> FAILED, expected 4 results, got %d", len(results))
 		t.Fail()
 	}
 
@@ -146,7 +280,78 @@ func TestWrite(t *testing.T) {
 	s = append(s, "DROP TABLE IF EXISTS "+testTableName()+"")
 	results, err = conn.Write(s)
 	if err != nil {
-		t.Logf("--> FAILED")
+		t.Logf("--> FAILED (%s)", err.Error())
+		t.Fail()
+	}
+}
+
+func TestWriteParameterized(t *testing.T) {
+	var results []WriteResult
+	var err error
+
+	t.Logf("trying Open")
+	conn, err := Open(testUrl())
+	if err != nil {
+		t.Logf("--> FATAL")
+		t.Fatal(err)
+	}
+
+	t.Logf("trying WriteParameterized DROP & CREATE")
+	results, err = conn.WriteParameterized(
+		[]ParameterizedStatement{
+			{
+				Query: fmt.Sprintf("DROP TABLE IF EXISTS %s", testTableName()),
+			},
+			{
+				Query: fmt.Sprintf("CREATE TABLE %s (id integer, name text)", testTableName()),
+			},
+		},
+	)
+	if err != nil {
+		t.Logf("--> FAILED (%s)", err.Error())
+		t.Fail()
+	}
+
+	t.Logf("trying WriteParameterized INSERT")
+	results, err = conn.WriteParameterized(
+		[]ParameterizedStatement{
+			{
+				Query:     fmt.Sprintf("INSERT INTO %s (id, name) VALUES (?, ?)", testTableName()),
+				Arguments: []interface{}{1, "aaa bbb ccc"},
+			},
+			{
+				Query:     fmt.Sprintf("INSERT INTO %s (id, name) VALUES (?, ?)", testTableName()),
+				Arguments: []interface{}{1, "aaa bbb ccc"},
+			},
+			{
+				Query:     fmt.Sprintf("INSERT INTO %s (id, name) VALUES (?, ?)", testTableName()),
+				Arguments: []interface{}{1, "aaa bbb ccc"},
+			},
+			{
+				Query:     fmt.Sprintf("INSERT INTO %s (id, name) VALUES (?, ?)", testTableName()),
+				Arguments: []interface{}{1, "aaa bbb ccc"},
+			},
+		},
+	)
+	if err != nil {
+		t.Logf("--> FAILED (%s)", err.Error())
+		t.Fail()
+	}
+	if len(results) != 4 {
+		t.Logf("--> FAILED, expected 4 results, got %d", len(results))
+		t.Fail()
+	}
+
+	t.Logf("trying WriteParameterized DROP")
+	results, err = conn.WriteParameterized(
+		[]ParameterizedStatement{
+			{
+				Query: fmt.Sprintf("DROP TABLE IF EXISTS %s", testTableName()),
+			},
+		},
+	)
+	if err != nil {
+		t.Logf("--> FAILED (%s)", err.Error())
 		t.Fail()
 	}
 }


### PR DESCRIPTION
Changes / Notes:

* Support for parameterized statements (e.g. parameter binding)
* Support for nullable types, similar to the database/sql package (e.g. sql.NullString, sql.NullInt64, etc...)
* Tests for the above added functionalities
* Other minor improvements
* Backwards compatible, no need for a v2

Examples:

- WriteParameterized:
```golang
wr, err := conn.WriteParameterized(
	[]gorqlite.ParameterizedStatement{
		{
			Query:     "INSERT INTO secret_agents(id, name, secret) VALUES(?, ?, ?)",
			Arguments: []interface{}{7, "James Bond", []byte{0x42}},
		},
	},
)
```

- WriteOneParameterized:
```golang
wr, err := conn.WriteOneParameterized(
	gorqlite.ParameterizedStatement{
		Query:     "INSERT INTO secret_agents(id, name, secret) VALUES(?, ?, ?)",
		Arguments: []interface{}{7, "James Bond", []byte{0x42}},
	},
)
```

- QueryParameterized / QueueParameterized: same syntax as WriteParameterized
- QueryOneParameterized / QueueOneParameterized: same syntax as WriteOneParameterized