### PR TITLE
Add a compatibility layer with database/sql in the standard library

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,6 +284,8 @@ By default, gorqlite uses this config for testing:
 	database URL : http://localhost:4001
 	table name   : gorqlite_test
 
+Also, the tests in package stdlib use the same config but a table name of `gorqlite_test_stdlib`.
+
 These can overridden using the environment variables:
 
 	GORQLITE_TEST_URL=https://somewhere.example.com:1234
@@ -291,6 +293,7 @@ These can overridden using the environment variables:
 	etc.
 
 	GORQLITE_TEST_TABLE=some_other_table
+	GORQLITE_TEST_TABLE_STDLIB=some_other_table
 
 ## Pronunciation
 rqlite is supposed to be pronounced "ree qwell lite".  So you could pronounce gorqlite as either "go ree kwell lite" or "gork lite".  The Klingon in me prefers the latter.  Really, isn't rqlite just the kind of battle-hardened, lean and mean system Klingons would use?  **Qapla'!**

--- a/api.go
+++ b/api.go
@@ -48,7 +48,11 @@ func (conn *Connection) rqliteApiCall(ctx context.Context, apiOp apiOperation, m
 		url := conn.assembleURL(apiOp, peer)
 
 		// Prepare request
-		req, err := http.NewRequestWithContext(ctx, method, url, bytes.NewBuffer(requestBody))
+		var bodyReader io.Reader
+		if requestBody != nil {
+			bodyReader = bytes.NewBuffer(requestBody)
+		}
+		req, err := http.NewRequestWithContext(ctx, method, url, bodyReader)
 		if err != nil {
 			trace("%s: got error '%s' doing http.NewRequest", conn.ID, err.Error())
 			failureLog = append(failureLog, fmt.Sprintf("%s failed due to %s", redactURL(url), err.Error()))

--- a/stdlib/sql.go
+++ b/stdlib/sql.go
@@ -1,0 +1,171 @@
+// Package stdlib provides a compatability layer from gorqlite to database/sql.
+package stdlib
+
+import (
+	"context"
+	"database/sql"
+	"database/sql/driver"
+	"fmt"
+	"io"
+
+	"github.com/rqlite/gorqlite"
+)
+
+func init() {
+	sql.Register("rqlite", &Driver{})
+}
+
+type Driver struct{}
+
+func (d *Driver) Open(name string) (driver.Conn, error) {
+	conn, err := gorqlite.Open(name)
+	if err != nil {
+		return nil, err
+	}
+	return &Conn{conn}, nil
+}
+
+type Conn struct {
+	*gorqlite.Connection
+}
+
+func (c *Conn) Prepare(query string) (driver.Stmt, error) {
+	return &Stmt{Stmt: query, Conn: c}, nil
+}
+
+func (c *Conn) Close() error {
+	c.Connection.Close()
+	return nil
+}
+
+func (c *Conn) Begin() (driver.Tx, error) {
+	return &Tx{}, nil
+}
+
+type Tx struct{}
+
+func (tx *Tx) Commit() error {
+	// no-op
+	return nil
+}
+
+func (tx *Tx) Rollback() error {
+	// no-op
+	return nil
+}
+
+type Stmt struct {
+	Stmt string
+	Conn *Conn
+}
+
+// these aren't checked automatically anywhere else, so we check them here
+var _ driver.StmtExecContext = (*Stmt)(nil)
+var _ driver.StmtQueryContext = (*Stmt)(nil)
+
+func (s *Stmt) Close() error {
+	return nil
+}
+
+func (s *Stmt) NumInput() int {
+	return -1
+}
+
+func (s *Stmt) Exec(args []driver.Value) (driver.Result, error) {
+	a := make([]interface{}, len(args))
+	for i, v := range args {
+		a[i] = v
+	}
+	stmt := gorqlite.ParameterizedStatement{Query: s.Stmt, Arguments: a}
+	wr, err := s.Conn.WriteOneParameterized(stmt)
+	if err != nil {
+		return &Result{wr}, err
+	}
+	return &Result{wr}, nil
+}
+
+func (s *Stmt) ExecContext(ctx context.Context, args []driver.NamedValue) (driver.Result, error) {
+	a := make([]interface{}, len(args))
+	for _, v := range args {
+		if v.Name != "" {
+			return nil, fmt.Errorf("rqlite: driver does not support named parameters, but got one with name %q in statement %q", v.Name, s.Stmt)
+		}
+		a[v.Ordinal-1] = v.Value
+	}
+	stmt := gorqlite.ParameterizedStatement{Query: s.Stmt, Arguments: a}
+	wr, err := s.Conn.WriteOneParameterizedContext(ctx, stmt)
+	if err != nil {
+		return &Result{wr}, err
+	}
+	return &Result{wr}, nil
+}
+
+func (s *Stmt) Query(args []driver.Value) (driver.Rows, error) {
+	a := make([]interface{}, len(args))
+	for i, v := range args {
+		a[i] = v
+	}
+	stmt := gorqlite.ParameterizedStatement{Query: s.Stmt, Arguments: a}
+	qr, err := s.Conn.QueryOneParameterized(stmt)
+	if err != nil {
+		return &Rows{qr}, err
+	}
+	return &Rows{qr}, nil
+}
+
+func (s *Stmt) QueryContext(ctx context.Context, args []driver.NamedValue) (driver.Rows, error) {
+	a := make([]interface{}, len(args))
+	for _, v := range args {
+		if v.Name != "" {
+			return nil, fmt.Errorf("rqlite: driver does not support named parameters, but got one with name %q in statement %q", v.Name, s.Stmt)
+		}
+		a[v.Ordinal-1] = v.Value
+	}
+	stmt := gorqlite.ParameterizedStatement{Query: s.Stmt, Arguments: a}
+	qr, err := s.Conn.QueryOneParameterizedContext(ctx, stmt)
+	if err != nil {
+		return &Rows{qr}, err
+	}
+	return &Rows{qr}, nil
+}
+
+type Result struct {
+	gorqlite.WriteResult
+}
+
+func (r *Result) LastInsertId() (int64, error) {
+	return r.WriteResult.LastInsertID, r.WriteResult.Err
+}
+
+func (r *Result) RowsAffected() (int64, error) {
+	return r.WriteResult.RowsAffected, r.WriteResult.Err
+}
+
+type Rows struct {
+	gorqlite.QueryResult
+}
+
+func (r *Rows) Columns() []string {
+	return r.QueryResult.Columns()
+}
+
+func (r *Rows) Close() error {
+	return r.Err
+}
+
+func (r *Rows) Next(dest []driver.Value) error {
+	ok := r.QueryResult.Next()
+	if !ok {
+		return io.EOF
+	}
+	// in Next, we are copying the values into the destination
+	// slice, not directly scanning them
+	slice, err := r.QueryResult.Slice()
+	if err != nil {
+		return err
+	}
+	for i, v := range slice {
+		dest[i] = v
+	}
+	return nil
+}

--- a/stdlib/sql_test.go
+++ b/stdlib/sql_test.go
@@ -1,0 +1,179 @@
+package stdlib
+
+import (
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"log"
+	"os"
+	"testing"
+	"time"
+)
+
+var globalDB *sql.DB
+
+func TestMain(m *testing.M) {
+	db, err := sql.Open("rqlite", testUrl())
+	if err != nil {
+		log.Fatalf("opening database: %v", err)
+	}
+	globalDB = db
+
+	exitCode := m.Run()
+
+	err = db.Close()
+	if err != nil {
+		log.Fatalf("closing database: %v", err)
+	}
+
+	os.Exit(exitCode)
+}
+
+func testUrl() string {
+	url := os.Getenv("GORQLITE_TEST_URL")
+	if url == "" {
+		url = "http://"
+	}
+	return url
+}
+
+func testTableName() string {
+	tableName := os.Getenv("GORQLITE_TEST_TABLE")
+	if tableName == "" {
+		tableName = "gorqlite_test"
+	}
+	return tableName
+}
+
+type payday struct {
+	Met string
+}
+
+func (p *payday) Scan(src interface{}) error {
+	str, ok := src.(string)
+	if !ok {
+		return fmt.Errorf("expected source of payday to be of type string, not %T", src)
+	}
+	return json.Unmarshal([]byte(str), p)
+}
+
+func TestTable(t *testing.T) {
+	// give an extra second for time diff between local and rqlite
+	started := time.Now().Add(-time.Second)
+
+	// When the Federation met the Cardassians
+	meeting := time.Date(2424, 1, 2, 17, 0, 0, 0, time.UTC)
+	met := fmt.Sprint(meeting.Unix())
+
+	t.Logf("trying Exec CREATE TABLE")
+
+	_, err := globalDB.Exec("CREATE TABLE " + testTableName() + " (id INTEGER, name TEXT, wallet REAL, bankrupt INTEGER, payload BLOB, ts DATETIME)")
+	if err != nil {
+		t.Errorf("create: %v", err)
+	}
+
+	t.Cleanup(func() {
+		_, err := globalDB.Exec("DROP TABLE " + testTableName())
+		if err != nil {
+			t.Errorf("dropping table: %v", err)
+		}
+	})
+
+	t.Run("Exec INSERT", func(t *testing.T) {
+		_, err = globalDB.Exec("INSERT INTO " + testTableName() + " (id, name, wallet, bankrupt, payload, ts) VALUES ( 1, 'Romulan', 123.456, 0, '{\"met\":\"" + met + "\"}', " + fmt.Sprint(time.Now().Unix()) + " )")
+		if err != nil {
+			t.Errorf("insert: %v", err)
+		}
+		_, err = globalDB.Exec("INSERT INTO " + testTableName() + " (id, name, wallet, bankrupt, payload, ts) VALUES ( 2, 'Vulcan', 123.456, 0, '{\"met\":\"" + met + "\"}', " + fmt.Sprint(time.Now().Unix()) + " )")
+		if err != nil {
+			t.Errorf("insert: %v", err)
+		}
+		_, err = globalDB.Exec("INSERT INTO " + testTableName() + " (id, name, wallet, bankrupt, payload, ts) VALUES ( 3, 'Klingon', 123.456, 1, '{\"met\":\"" + met + "\"}', " + fmt.Sprint(time.Now().Unix()) + " )")
+		if err != nil {
+			t.Errorf("insert: %v", err)
+		}
+		_, err = globalDB.Exec("INSERT INTO " + testTableName() + " (id, name, wallet, bankrupt, payload, ts) VALUES ( 4, 'Ferengi', 123.456, 0, '{\"met\":\"" + met + "\"}', " + fmt.Sprint(time.Now().Unix()) + " )")
+		if err != nil {
+			t.Errorf("insert: %v", err)
+		}
+		_, err = globalDB.Exec("INSERT INTO " + testTableName() + " (id, name, wallet, bankrupt, payload, ts) VALUES ( 5, 'Cardassian', 123.456, 1, '{\"met\":\"" + met + "\"}', " + met + " )")
+		if err != nil {
+			t.Errorf("insert: %v", err)
+		}
+	})
+
+	t.Run("Query SELECT", func(t *testing.T) {
+		rows, err := globalDB.Query("SELECT name, ts, wallet, bankrupt, payload FROM " + testTableName() + " WHERE id > 3")
+		if err != nil {
+			t.Fatalf("select: %v", err)
+		}
+		defer rows.Close()
+
+		columns, err := rows.Columns()
+		if err != nil {
+			t.Errorf("getting columns: %v", err)
+		}
+		if len(columns) != 5 {
+			t.Errorf("expected 5 columns, got %v", len(columns))
+		} else {
+			expect := []string{"name", "ts", "wallet", "bankrupt", "payload"}
+			for i, c := range columns {
+				if c != expect[i] {
+					t.Errorf("expected column %v to be %v, got %v", i, expect[i], c)
+				}
+			}
+		}
+
+		i := 0
+		for rows.Next() {
+			var name string
+			var ts time.Time
+			var wallet float64
+			var bankrupt int
+			var payday payday
+			err := rows.Scan(&name, &ts, &wallet, &bankrupt, &payday)
+			if err != nil {
+				t.Errorf("scanning: %v", err)
+			}
+			if i == 0 {
+				if name != "Ferengi" {
+					t.Errorf("got incorrect name: %s", name)
+				}
+				if bankrupt != 0 {
+					t.Errorf("got incorrect bankrupt: %d", bankrupt)
+				}
+			} else if i == 1 {
+				if name != "Cardassian" {
+					t.Errorf("got incorrect name: %s", name)
+				}
+				if bankrupt != 1 {
+					t.Errorf("got incorrect bankrupt: %d", bankrupt)
+				}
+			}
+			if ts.IsZero() || ts.Before(started) {
+				t.Errorf("got incorrect time: %v", ts)
+			}
+			if wallet != 123.456 {
+				t.Errorf("got incorrect wallet: %g", wallet)
+			}
+			if payday != struct{ Met string }{
+				Met: fmt.Sprint(time.Date(2424, 1, 2, 17, 0, 0, 0, time.UTC).Unix()),
+			} {
+				t.Errorf("got incorrect payday: %v", payday)
+			}
+
+			i++
+		}
+
+		if i != 2 {
+			t.Errorf("expected 2 rows, got %v", i)
+		}
+	})
+
+	t.Run("Invalid Query", func(t *testing.T) {
+		_, err := globalDB.Query("INVALID QUERY")
+		if err == nil {
+			t.Errorf("expected error for invalid query, got nil")
+		}
+	})
+}

--- a/stdlib/sql_test.go
+++ b/stdlib/sql_test.go
@@ -38,9 +38,9 @@ func testUrl() string {
 }
 
 func testTableName() string {
-	tableName := os.Getenv("GORQLITE_TEST_TABLE")
+	tableName := os.Getenv("GORQLITE_TEST_TABLE_STDLIB")
 	if tableName == "" {
-		tableName = "gorqlite_test"
+		tableName = "gorqlite_test_stdlib"
 	}
 	return tableName
 }


### PR DESCRIPTION
I understand the reasons stated in the readme on why a `database/sql` driver was not made. However, although directly using a gorqlite-specific API provides a better experience, an additional `database/sql` driver would significantly broaden the reach of gorqlite by allowing it to be used with other libraries like GORM. In fact, the main reason I wrote this PR is so that I can write a GORM driver for gorqlite.

This PR introduces a simple wrapper library, `stdlib`, which implements `database/sql/driver` interfaces. The implementations are trivial wrappers of already existing functions in the main `gorqlite` package, and no functionality in the main package is lost. This structure is based on [jackc/pgx](https://github.com/jackc/pgx), which is a popular Go PostgreSQL driver.

There are only two changes to the main package in this PR:

1. The addition of `QueryResult.Slice`, which is necessary because `database/sql/driver.Rows.Next` needs to copy the values into a destination slice of `driver.Value` objects. It is based on `QueryResult.Map`, and has effectively the same API and code, just with a slice instead of a map.
2. A simple if statement in `Connection.rqliteApiCall` which ensures that a nil request body reader is passed for a nil request body. This is necessary because browsers are very strict about having empty bodies on `GET` requests, so an empty but non-nil buffer results in all gorqlite HTTP `GET` requests failing in browsers.