### PR TITLE
gracefully handle store not open statuses

### DIFF
--- a/cluster.go
+++ b/cluster.go
@@ -139,7 +139,12 @@ func (conn *Connection) updateClusterInfo() error {
 	if ok {
 		leaderRaftAddr = leaderMap["node_id"].(string)
 	} else {
-		leaderRaftAddr = sMap["leader"].(string)
+		addr, ok := sMap["leader"].(string)
+		if !ok {
+			return errors.New("store is not open")
+		}
+
+		leaderRaftAddr = addr
 	}
 	trace("%s: leader from store section is %s", conn.ID, leaderRaftAddr)
 


### PR DESCRIPTION
If rqlite's store is not yet open, the store status JSON looks like:

```json
{
  "open": false
}
```

There is no other information included. This causes gorqlite to panic because we assume there is always a "leader" field filled out, which is not the case before the store has opened.

I wasn't sure if this is exactly the way you'd like this fixed; technically we could change [rqlite](https://github.com/rqlite/rqlite/blob/master/store/store.go#L899-L903) to have this information in the status endpoint as well, I think? I also wasn't too sure how to add a test for this, but would be willing to add one if you could point me to the proper place.

Thanks!