### PR TITLE
Implement methods allowing to use the Unified Endpoint

### DIFF
--- a/api.go
+++ b/api.go
@@ -139,7 +139,7 @@ func (conn *Connection) rqliteApiPost(ctx context.Context, apiOp apiOperation, s
 	var responseBody []byte
 
 	// Allow only api_QUERY and api_WRITE
-	if apiOp != api_QUERY && apiOp != api_WRITE {
+	if apiOp != api_QUERY && apiOp != api_WRITE && apiOp != api_REQUEST {
 		return responseBody, errors.New("rqliteApiPost() called for invalid api operation")
 	}
 

--- a/api.go
+++ b/api.go
@@ -138,7 +138,7 @@ func (conn *Connection) rqliteApiGet(ctx context.Context, apiOp apiOperation) ([
 func (conn *Connection) rqliteApiPost(ctx context.Context, apiOp apiOperation, sqlStatements []ParameterizedStatement) ([]byte, error) {
 	var responseBody []byte
 
-	// Allow only api_QUERY and api_WRITE
+	// Allow only api_QUERY, api_WRITE and api_REQUEST
 	if apiOp != api_QUERY && apiOp != api_WRITE && apiOp != api_REQUEST {
 		return responseBody, errors.New("rqliteApiPost() called for invalid api operation")
 	}

--- a/cluster.go
+++ b/cluster.go
@@ -83,9 +83,11 @@ func (conn *Connection) assembleURL(apiOp apiOperation, p peer) string {
 		builder.WriteString("/db/query")
 	case api_WRITE:
 		builder.WriteString("/db/execute")
+	case api_REQUEST:
+		builder.WriteString("/db/request")
 	}
 
-	if apiOp == api_QUERY || apiOp == api_WRITE {
+	if apiOp == api_QUERY || apiOp == api_WRITE || apiOp == api_REQUEST {
 		builder.WriteString("?timings&level=")
 		builder.WriteString(consistencyLevelNames[conn.consistencyLevel])
 		if conn.wantsTransactions {
@@ -105,6 +107,8 @@ func (conn *Connection) assembleURL(apiOp apiOperation, p peer) string {
 		trace("%s: assembled URL for an api_NODES: %s", conn.ID, builder.String())
 	case api_WRITE:
 		trace("%s: assembled URL for an api_WRITE: %s", conn.ID, builder.String())
+	case api_REQUEST:
+		trace("%s: assembled URL for an api_REQUEST: %s", conn.ID, builder.String())
 	}
 
 	return builder.String()

--- a/gorqlite.go
+++ b/gorqlite.go
@@ -48,6 +48,7 @@ const (
 	api_STATUS
 	api_WRITE
 	api_NODES
+	api_REQUEST
 )
 
 func init() {

--- a/request.go
+++ b/request.go
@@ -1,0 +1,171 @@
+package gorqlite
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+)
+
+// RequestResult holds the result of a single statement sent to Unified Endpoint.
+//
+// If statement failed, Err contains the error, neither Query nor Write is set.
+// If statement succeeded, either of Query or Write is set — depending on the type of the statement.
+// Query.Err and Write.Err are never set.
+type RequestResult struct {
+	Err   error
+	Query *QueryResult
+	Write *WriteResult
+}
+
+// Request is used to access Unified Endpoint to send read and writes requests in one operation.
+func (conn *Connection) Request(sqlStatements []string) (results []RequestResult, err error) {
+	parameterizedStatements := make([]ParameterizedStatement, 0, len(sqlStatements))
+	for _, sqlStatement := range sqlStatements {
+		parameterizedStatements = append(parameterizedStatements, ParameterizedStatement{
+			Query: sqlStatement,
+		})
+	}
+
+	return conn.RequestParameterized(parameterizedStatements)
+}
+
+// RequestContext is used to access Unified Endpoint to send read and writes requests in one operation.
+//
+// To use RequestContext with parameterized queries, use RequestParameterizedContext.
+func (conn *Connection) RequestContext(ctx context.Context, sqlStatements []string) (results []RequestResult, err error) {
+	parameterizedStatements := make([]ParameterizedStatement, 0, len(sqlStatements))
+	for _, sqlStatement := range sqlStatements {
+		parameterizedStatements = append(parameterizedStatements, ParameterizedStatement{
+			Query: sqlStatement,
+		})
+	}
+
+	return conn.RequestParameterizedContext(ctx, parameterizedStatements)
+}
+
+// RequestParameterized is used to access Unified Endpoint to send read and writes requests in one operation.
+//
+// It takes an array of parameterized SQL statements and executes them in a single transaction,
+// returning an array of RequestResult vars.
+
+// RequestParameterized returns an error if one is encountered during its operation.
+// If it's something like a call to the rqlite API, then it'll return that error.
+// If one statement out of several has an error, it will return a generic
+// "there were %d statement errors" and you'll have to look at the individual statement's Err for more info.
+//
+// RequestParameterized uses context.Background() internally; to specify the context, use RequestParameterizedContext.
+func (conn *Connection) RequestParameterized(sqlStatements []ParameterizedStatement) (results []RequestResult, err error) {
+	return conn.RequestParameterizedContext(context.Background(), sqlStatements)
+}
+
+// RequestParameterizedContext is used to access Unified Endpoint to send read and writes requests in one operation.
+//
+// It takes an array of parameterized SQL statements and executes them in a single transaction,
+// returning an array of RequestResult vars.
+
+// RequestParameterizedContext returns an error if one is encountered during its operation.
+// If it's something like a call to the rqlite API, then it'll return that error.
+// If one statement out of several has an error, it will return a generic
+// "there were %d statement errors" and you'll have to look at the individual statement's Err for more info.
+func (conn *Connection) RequestParameterizedContext(ctx context.Context, sqlStatements []ParameterizedStatement) (results []RequestResult, err error) {
+	results = make([]RequestResult, 0)
+
+	if conn.hasBeenClosed {
+		var errResult RequestResult
+		errResult.Err = ErrClosed
+		results = append(results, errResult)
+		return results, ErrClosed
+	}
+
+	trace("%s: Request() for %d statements", conn.ID, len(sqlStatements))
+
+	before := time.Now()
+	// if we get an error POSTing, that's a showstopper
+	response, err := conn.rqliteApiPost(ctx, api_REQUEST, sqlStatements)
+	after := time.Now()
+	if err != nil {
+		trace("%s: rqliteApiCall() ERROR: %s", conn.ID, err.Error())
+		var errResult RequestResult
+		errResult.Err = err
+		results = append(results, errResult)
+		return results, err
+	}
+	trace("%s: rqliteApiCall() OK, duration: %s", conn.ID, after.Sub(before))
+
+	// if we get an error Unmarshaling, that's a showstopper
+	var sections map[string]interface{}
+	err = json.Unmarshal(response, &sections)
+
+	if err != nil {
+		trace("%s: json.Unmarshal() ERROR: %s", conn.ID, err.Error())
+		var errResult RequestResult
+		errResult.Err = err
+		results = append(results, errResult)
+		return results, err
+	}
+
+	// if we got an error from the api, that's a showstopper
+	if errMsg, ok := sections["error"].(string); ok && errMsg != "" {
+		trace("%s: api ERROR: %s", conn.ID, errMsg)
+		var errResult RequestResult
+		errResult.Err = fmt.Errorf("%s", errMsg)
+		results = append(results, errResult)
+		return results, errResult.Err
+	}
+
+	// at this point, we have a "results" section and
+	// a "time" section.  we can ignore the latter.
+
+	resultsArray, ok := sections["results"].([]interface{})
+	if !ok {
+		err = errors.New("result key is missing from response")
+		trace("%s: sections[\"results\"] ERROR: %s", conn.ID, err)
+		var errResult RequestResult
+		errResult.Err = err
+		results = append(results, errResult)
+		return results, err
+	}
+
+	numStatementErrors := 0
+	for n, r := range resultsArray {
+		trace("%s: parsing result %d", conn.ID, n)
+		var thisR RequestResult
+
+		// r is a hash with columns, types, values, and time
+		thisResult := r.(map[string]interface{})
+
+		// did we get an error?
+		_, ok := thisResult["error"]
+		if ok {
+			trace("%s: have an error on this result: %s", conn.ID, thisResult["error"].(string))
+			thisR.Err = errors.New(thisResult["error"].(string))
+			results = append(results, thisR)
+			numStatementErrors++
+			continue
+		}
+
+		_, hasValues := thisResult["values"]
+		_, hasColumns := thisResult["columns"]
+		if hasValues || hasColumns {
+			// Presence of these keys means this is a query result
+			qr := conn.parseQueryResult(thisResult)
+			qr.conn = conn
+			thisR.Query = &qr
+		} else {
+			wr := conn.parseWriteResult(thisResult)
+			wr.conn = conn
+			thisR.Write = &wr
+		}
+		results = append(results, thisR)
+	}
+
+	trace("%s: finished parsing, returning %d results", conn.ID, len(results))
+
+	if numStatementErrors > 0 {
+		return results, fmt.Errorf("there were %d statement errors", numStatementErrors)
+	}
+
+	return results, nil
+}

--- a/request.go
+++ b/request.go
@@ -97,7 +97,6 @@ func (conn *Connection) RequestParameterizedContext(ctx context.Context, sqlStat
 	// if we get an error Unmarshaling, that's a showstopper
 	var sections map[string]interface{}
 	err = json.Unmarshal(response, &sections)
-
 	if err != nil {
 		trace("%s: json.Unmarshal() ERROR: %s", conn.ID, err.Error())
 		var errResult RequestResult

--- a/request_test.go
+++ b/request_test.go
@@ -1,0 +1,108 @@
+package gorqlite_test
+
+import (
+	"context"
+	"fmt"
+	"github.com/rqlite/gorqlite"
+	"testing"
+	"time"
+)
+
+func TestRequestParameterized(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*30)
+	defer cancel()
+
+	wr, err := globalConnection.WriteOneContext(ctx, "CREATE TABLE "+testTableName()+" (id INTEGER, name TEXT)")
+	if err != nil {
+		t.Fatalf("creating table: %s - %s", err.Error(), wr.Err.Error())
+	}
+
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second*30)
+		defer cancel()
+
+		wr, err := globalConnection.WriteOneContext(ctx, "DROP TABLE "+testTableName())
+		if err != nil {
+			t.Errorf("dropping table: %s - %s", err.Error(), wr.Err.Error())
+		}
+	})
+
+	t.Run("DROP", func(t *testing.T) {
+		tableName := RandStringBytes(8)
+		_, err := globalConnection.RequestParameterized(
+			[]gorqlite.ParameterizedStatement{
+				{
+					Query: fmt.Sprintf("CREATE TABLE %s (id integer, name text)", tableName),
+				},
+				{
+					Query: fmt.Sprintf("DROP TABLE IF EXISTS %s", tableName),
+				},
+			},
+		)
+		if err != nil {
+			t.Errorf("failed during dropping & creating table: %s", err.Error())
+		}
+	})
+
+	t.Run("INSERT and SELECT", func(t *testing.T) {
+		results, err := globalConnection.RequestParameterized(
+			[]gorqlite.ParameterizedStatement{
+				{
+					Query:     fmt.Sprintf("INSERT INTO %s (id, name) VALUES (?, ?)", testTableName()),
+					Arguments: []interface{}{1, "aaa"},
+				},
+				{
+					Query:     fmt.Sprintf("INSERT INTO %s (id, name) VALUES (?, ?)", testTableName()),
+					Arguments: []interface{}{2, "bbb"},
+				},
+				{
+					Query:     fmt.Sprintf("SELECT id, name FROM %s WHERE name > ?", testTableName()),
+					Arguments: []interface{}{"aaa"},
+				},
+			},
+		)
+		if err != nil {
+			t.Errorf("making multiple parameterized requests: %s", err.Error())
+		}
+
+		if len(results) != 3 {
+			t.Errorf("expected 3 results, got %d", len(results))
+		}
+
+		res := results[0]
+		wr := res.Write
+		if wr == nil {
+			t.Error("unexpected results[0] type")
+		}
+		if wr.RowsAffected != 1 {
+			t.Errorf("results[0].Write.RowsAffected must be 1")
+		}
+
+		res = results[1]
+		wr = res.Write
+		if wr == nil {
+			t.Error("unexpected results[1] type")
+		}
+		if wr.RowsAffected != 1 {
+			t.Errorf("results[1].Write.RowsAffected must be 1")
+		}
+
+		res = results[2]
+		qr := res.Query
+		if qr == nil {
+			t.Error("unexpected results[2] type")
+		}
+		if qr.NumRows() != 1 {
+			t.Errorf("failed to scan from results[2].Query.NumRows() must be 1, not %d", qr.NumRows())
+		}
+		qr.Next()
+		var id int
+		var name string
+		if err := qr.Scan(&id, &name); err != nil {
+			t.Errorf("failed to scan from results[2].Query: %v", err)
+		}
+		if id != 2 || name != "bbb" {
+			t.Errorf("incorrect results[2].Query result: expected id == 2 && name == bbb, got id == %d && name == %s", id, name)
+		}
+	})
+}


### PR DESCRIPTION
Implemented `Request`, `RequestContext`, `RequestParameterized` and `RequestParameterizedContext` methods.

I've factored out `parseWriteResult` and `parseReadResult` from `WriteParameterizedContext` and `QueryParameterizedContext` to reuse them within `RequestParameterizedContext` implementation.

This is just an initial approach. If it seems feasible, I will add more tests.