### PR TITLE
Support error unwrapping and include detail in statement errors, fixes #46

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ results, err := conn.Write(statements)
 
 for n, v := range WriteResult {
 	fmt.Printf("for result %d, %d rows were affected\n",n,v.RowsAffected)
-	if ( v.Err != nil ) {
+	if v.Err != nil {
 		fmt.Printf("   we have this error: %s\n",v.Err.Error())
 	}
 }

--- a/error.go
+++ b/error.go
@@ -1,6 +1,7 @@
 package gorqlite
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 )
@@ -9,12 +10,25 @@ var _ error = StatementErrors{}
 
 type StatementErrors []error
 
+func joinErrors(errs ...error) error {
+	if len(errs) == 0 {
+		return nil
+	}
+	var se StatementErrors
+	for _, err := range errs {
+		if err == nil {
+			continue
+		}
+		se = append(se, err)
+	}
+	if len(se) == 0 {
+		return nil
+	}
+	return se
+}
+
 // Error returns a string representation of the statement errors.
 func (errs StatementErrors) Error() string {
-	if len(errs) == 0 {
-		return ""
-	}
-
 	var sb strings.Builder
 	sb.WriteString(fmt.Sprintf("there were %d statement errors", len(errs)))
 	for _, err := range errs {
@@ -27,4 +41,24 @@ func (errs StatementErrors) Error() string {
 // Unwrap returns the slice of statement errors.
 func (errs StatementErrors) Unwrap() []error {
 	return errs
+}
+
+// Is returns true if the current error, or one of the statement errors is equal to the target error.
+func (errs StatementErrors) Is(target error) bool {
+	for _, err := range errs {
+		if errors.Is(err, target) {
+			return true
+		}
+	}
+	return false
+}
+
+// As returns true if the current error, or one of the statement errors can be assigned to the target error.
+func (errs StatementErrors) As(target interface{}) bool {
+	for _, err := range errs {
+		if errors.As(err, target) {
+			return true
+		}
+	}
+	return false
 }

--- a/error.go
+++ b/error.go
@@ -1,0 +1,30 @@
+package gorqlite
+
+import (
+	"fmt"
+	"strings"
+)
+
+var _ error = StatementErrors{}
+
+type StatementErrors []error
+
+// Error returns a string representation of the statement errors.
+func (errs StatementErrors) Error() string {
+	if len(errs) == 0 {
+		return ""
+	}
+
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("there were %d statement errors", len(errs)))
+	for _, err := range errs {
+		sb.WriteString("\n")
+		sb.WriteString(err.Error())
+	}
+	return sb.String()
+}
+
+// Unwrap returns the slice of statement errors.
+func (errs StatementErrors) Unwrap() []error {
+	return errs
+}

--- a/error_test.go
+++ b/error_test.go
@@ -1,0 +1,44 @@
+package gorqlite
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestStatementErrors(t *testing.T) {
+	t.Run("returns an empty string if there are no errors", func(t *testing.T) {
+		var err StatementErrors
+		expected := ""
+		actual := err.Error()
+		if actual != expected {
+			t.Errorf("expected %q, got %q", expected, actual)
+		}
+	})
+	t.Run("returns a string representation of the statement errors", func(t *testing.T) {
+		err := StatementErrors{
+			errors.New("error 1"),
+			errors.New("error 2"),
+		}
+		expected := "there were 2 statement errors\nerror 1\nerror 2"
+		actual := err.Error()
+		if actual != expected {
+			t.Errorf("expected %q, got %q", expected, actual)
+		}
+	})
+	t.Run("can unwrap the slice of statement errors", func(t *testing.T) {
+		var errs StatementErrors
+		var err1 = errors.New("error 1")
+		var err2 = errors.New("error 2")
+		errs = append(errs, err1, err2)
+		expected := []error{err1, err2}
+		actual := errs.Unwrap()
+		if len(actual) != len(expected) {
+			t.Errorf("expected %v, got %v", expected, actual)
+		}
+		for i, err := range actual {
+			if err != expected[i] {
+				t.Errorf("expected %v, got %v", expected, actual)
+			}
+		}
+	})
+}

--- a/error_test.go
+++ b/error_test.go
@@ -6,32 +6,44 @@ import (
 )
 
 func TestStatementErrors(t *testing.T) {
-	t.Run("returns an empty string if there are no errors", func(t *testing.T) {
-		var err StatementErrors
-		expected := ""
-		actual := err.Error()
-		if actual != expected {
-			t.Errorf("expected %q, got %q", expected, actual)
+	t.Run("returns nil when there are no errors", func(t *testing.T) {
+		err := joinErrors()
+		if err != nil {
+			t.Errorf("expected nil, got %v", err)
 		}
 	})
-	t.Run("returns a string representation of the statement errors", func(t *testing.T) {
-		err := StatementErrors{
-			errors.New("error 1"),
-			errors.New("error 2"),
+	t.Run("returns nil when there are only nil errors", func(t *testing.T) {
+		err := joinErrors(nil, nil)
+		if err != nil {
+			t.Errorf("expected nil, got %v", err)
 		}
+	})
+	t.Run("ignores nil errors", func(t *testing.T) {
+		err := joinErrors(errors.New("error 1"), nil, errors.New("error 2"))
 		expected := "there were 2 statement errors\nerror 1\nerror 2"
 		actual := err.Error()
 		if actual != expected {
-			t.Errorf("expected %q, got %q", expected, actual)
+			t.Errorf("expected %v, got %v", expected, actual)
+		}
+	})
+	t.Run("returns a string representation of the statement errors", func(t *testing.T) {
+		err := joinErrors(errors.New("error 1"), errors.New("error 2"))
+		expected := "there were 2 statement errors\nerror 1\nerror 2"
+		actual := err.Error()
+		if actual != expected {
+			t.Errorf("expected %v, got %v", expected, actual)
 		}
 	})
 	t.Run("can unwrap the slice of statement errors", func(t *testing.T) {
-		var errs StatementErrors
 		var err1 = errors.New("error 1")
 		var err2 = errors.New("error 2")
-		errs = append(errs, err1, err2)
+		err := joinErrors(err1, err2)
 		expected := []error{err1, err2}
-		actual := errs.Unwrap()
+		unwrap, canUnwrap := err.(interface{ Unwrap() []error })
+		if !canUnwrap {
+			t.Fatal("cannot unwrap the statement errors")
+		}
+		actual := unwrap.Unwrap()
 		if len(actual) != len(expected) {
 			t.Errorf("expected %v, got %v", expected, actual)
 		}
@@ -41,4 +53,51 @@ func TestStatementErrors(t *testing.T) {
 			}
 		}
 	})
+	t.Run("can check if an error is wrapped, but present", func(t *testing.T) {
+		var err1 = errors.New("error 1")
+		var err2 = errors.New("error 2")
+		err := joinErrors(err1, err2)
+		if !errors.Is(err, err1) {
+			t.Errorf("expected true, got false")
+		}
+	})
+	t.Run("can check if an error is wrapped, but not present", func(t *testing.T) {
+		var err1 = errors.New("error 1")
+		var err2 = errors.New("error 2")
+		err := joinErrors(err1)
+		if errors.Is(err, err2) {
+			t.Errorf("expected false, got true")
+		}
+	})
+	t.Run("can assign the error to a target", func(t *testing.T) {
+		var err1 = errors.New("error 1")
+		var err2 = testError{msg: "error 2"}
+		err := joinErrors(err1, err2)
+
+		var target testError
+		if !errors.As(err, &target) {
+			t.Errorf("expected true, got false")
+		}
+		if target != err2 {
+			t.Errorf("expected %v, got %v", err2, target)
+		}
+	})
+	t.Run("does not assign if the target is not the same type", func(t *testing.T) {
+		var err1 = errors.New("error 1")
+		var err2 = errors.New("error 2")
+		err := joinErrors(err1, err2)
+
+		var target testError
+		if errors.As(err, &target) {
+			t.Errorf("expected false, got true")
+		}
+	})
+}
+
+type testError struct {
+	msg string
+}
+
+func (e testError) Error() string {
+	return e.msg
 }

--- a/query.go
+++ b/query.go
@@ -291,20 +291,20 @@ func (conn *Connection) QueryParameterizedContext(ctx context.Context, sqlStatem
 	resultsArray := sections["results"].([]interface{})
 	trace("%s: I have %d result(s) to parse", conn.ID, len(resultsArray))
 
-	var statementErrors StatementErrors
+	var errs []error
 	for n, r := range resultsArray {
 		trace("%s: parsing result %d", conn.ID, n)
 		qr := conn.parseQueryResult(r.(map[string]interface{}))
 		qr.conn = conn
 		results = append(results, qr)
 		if qr.Err != nil {
-			statementErrors = append(statementErrors, qr.Err)
+			errs = append(errs, qr.Err)
 		}
 	}
 
 	trace("%s: finished parsing, returning %d results", conn.ID, len(results))
 
-	return results, statementErrors
+	return results, joinErrors(errs...)
 }
 
 /* *****************************************************************

--- a/query.go
+++ b/query.go
@@ -291,24 +291,20 @@ func (conn *Connection) QueryParameterizedContext(ctx context.Context, sqlStatem
 	resultsArray := sections["results"].([]interface{})
 	trace("%s: I have %d result(s) to parse", conn.ID, len(resultsArray))
 
-	numStatementErrors := 0
+	var statementErrors StatementErrors
 	for n, r := range resultsArray {
 		trace("%s: parsing result %d", conn.ID, n)
 		qr := conn.parseQueryResult(r.(map[string]interface{}))
 		qr.conn = conn
 		results = append(results, qr)
 		if qr.Err != nil {
-			numStatementErrors++
+			statementErrors = append(statementErrors, qr.Err)
 		}
 	}
 
 	trace("%s: finished parsing, returning %d results", conn.ID, len(results))
 
-	if numStatementErrors > 0 {
-		return results, fmt.Errorf("there were %d statement errors", numStatementErrors)
-	}
-
-	return results, nil
+	return results, statementErrors
 }
 
 /* *****************************************************************

--- a/request.go
+++ b/request.go
@@ -52,8 +52,7 @@ func (conn *Connection) RequestContext(ctx context.Context, sqlStatements []stri
 
 // RequestParameterized returns an error if one is encountered during its operation.
 // If it's something like a call to the rqlite API, then it'll return that error.
-// If one statement out of several has an error, it will return a generic
-// "there were %d statement errors" and you'll have to look at the individual statement's Err for more info.
+// If one statement out of several has an error, you can look at the individual statement's Err for more info.
 //
 // RequestParameterized uses context.Background() internally; to specify the context, use RequestParameterizedContext.
 func (conn *Connection) RequestParameterized(sqlStatements []ParameterizedStatement) (results []RequestResult, err error) {
@@ -67,8 +66,7 @@ func (conn *Connection) RequestParameterized(sqlStatements []ParameterizedStatem
 
 // RequestParameterizedContext returns an error if one is encountered during its operation.
 // If it's something like a call to the rqlite API, then it'll return that error.
-// If one statement out of several has an error, it will return a generic
-// "there were %d statement errors" and you'll have to look at the individual statement's Err for more info.
+// If one statement out of several has an error, you can look at the individual statement's Err for more info.
 func (conn *Connection) RequestParameterizedContext(ctx context.Context, sqlStatements []ParameterizedStatement) (results []RequestResult, err error) {
 	results = make([]RequestResult, 0)
 

--- a/request.go
+++ b/request.go
@@ -127,7 +127,7 @@ func (conn *Connection) RequestParameterizedContext(ctx context.Context, sqlStat
 		return results, err
 	}
 
-	numStatementErrors := 0
+	var statementErrors StatementErrors
 	for n, r := range resultsArray {
 		trace("%s: parsing result %d", conn.ID, n)
 		var thisR RequestResult
@@ -141,7 +141,7 @@ func (conn *Connection) RequestParameterizedContext(ctx context.Context, sqlStat
 			trace("%s: have an error on this result: %s", conn.ID, thisResult["error"].(string))
 			thisR.Err = errors.New(thisResult["error"].(string))
 			results = append(results, thisR)
-			numStatementErrors++
+			statementErrors = append(statementErrors, thisR.Err)
 			continue
 		}
 
@@ -162,9 +162,5 @@ func (conn *Connection) RequestParameterizedContext(ctx context.Context, sqlStat
 
 	trace("%s: finished parsing, returning %d results", conn.ID, len(results))
 
-	if numStatementErrors > 0 {
-		return results, fmt.Errorf("there were %d statement errors", numStatementErrors)
-	}
-
-	return results, nil
+	return results, statementErrors
 }

--- a/request.go
+++ b/request.go
@@ -127,7 +127,7 @@ func (conn *Connection) RequestParameterizedContext(ctx context.Context, sqlStat
 		return results, err
 	}
 
-	var statementErrors StatementErrors
+	var errs []error
 	for n, r := range resultsArray {
 		trace("%s: parsing result %d", conn.ID, n)
 		var thisR RequestResult
@@ -141,7 +141,7 @@ func (conn *Connection) RequestParameterizedContext(ctx context.Context, sqlStat
 			trace("%s: have an error on this result: %s", conn.ID, thisResult["error"].(string))
 			thisR.Err = errors.New(thisResult["error"].(string))
 			results = append(results, thisR)
-			statementErrors = append(statementErrors, thisR.Err)
+			errs = append(errs, thisR.Err)
 			continue
 		}
 
@@ -162,5 +162,5 @@ func (conn *Connection) RequestParameterizedContext(ctx context.Context, sqlStat
 
 	trace("%s: finished parsing, returning %d results", conn.ID, len(results))
 
-	return results, statementErrors
+	return results, joinErrors(errs...)
 }

--- a/write.go
+++ b/write.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"fmt"
 )
 
 /* *****************************************************************
@@ -208,24 +207,20 @@ func (conn *Connection) WriteParameterizedContext(ctx context.Context, sqlStatem
 		return results, err
 	}
 	trace("%s: I have %d result(s) to parse", conn.ID, len(resultsArray))
-	numStatementErrors := 0
+	var statementErrors StatementErrors
 	for n, k := range resultsArray {
 		trace("%s: starting on result %d", conn.ID, n)
 		wr := conn.parseWriteResult(k.(map[string]interface{}))
 		wr.conn = conn
 		results = append(results, wr)
 		if wr.Err != nil {
-			numStatementErrors += 1
+			statementErrors = append(statementErrors, wr.Err)
 		}
 	}
 
 	trace("%s: finished parsing, returning %d results", conn.ID, len(results))
 
-	if numStatementErrors > 0 {
-		return results, fmt.Errorf("there were %d statement errors", numStatementErrors)
-	} else {
-		return results, nil
-	}
+	return results, statementErrors
 }
 
 // QueueOne is a convenience method that wraps Queue into a single-statement.

--- a/write.go
+++ b/write.go
@@ -207,20 +207,20 @@ func (conn *Connection) WriteParameterizedContext(ctx context.Context, sqlStatem
 		return results, err
 	}
 	trace("%s: I have %d result(s) to parse", conn.ID, len(resultsArray))
-	var statementErrors StatementErrors
+	var errs []error
 	for n, k := range resultsArray {
 		trace("%s: starting on result %d", conn.ID, n)
 		wr := conn.parseWriteResult(k.(map[string]interface{}))
 		wr.conn = conn
 		results = append(results, wr)
 		if wr.Err != nil {
-			statementErrors = append(statementErrors, wr.Err)
+			errs = append(errs, wr.Err)
 		}
 	}
 
 	trace("%s: finished parsing, returning %d results", conn.ID, len(results))
 
-	return results, statementErrors
+	return results, joinErrors(errs...)
 }
 
 // QueueOne is a convenience method that wraps Queue into a single-statement.

--- a/write.go
+++ b/write.go
@@ -116,8 +116,7 @@ func (conn *Connection) WriteContext(ctx context.Context, sqlStatements []string
 //
 // WriteParameterized returns an error if one is encountered during its operation.
 // If it's something like a call to the rqlite API, then it'll return that error.
-// If one statement out of several has an error, it will return a generic
-// "there were %d statement errors" and you'll have to look at the individual statement's Err for more info.
+// If one statement out of several has an error, you can look at the individual statement's Err for more info.
 //
 // WriteParameterized uses context.Background() internally; to specify the context, use WriteParameterizedContext.
 func (conn *Connection) WriteParameterized(sqlStatements []ParameterizedStatement) (results []WriteResult, err error) {
@@ -160,8 +159,7 @@ func (conn *Connection) parseWriteResult(thisResult map[string]interface{}) Writ
 //
 // WriteParameterizedContext returns an error if one is encountered during its operation.
 // If it's something like a call to the rqlite API, then it'll return that error.
-// If one statement out of several has an error, it will return a generic
-// "there were %d statement errors" and you'll have to look at the individual statement's Err for more info.
+// If one statement out of several has an error, you can look at the individual statement's Err for more info.
 func (conn *Connection) WriteParameterizedContext(ctx context.Context, sqlStatements []ParameterizedStatement) (results []WriteResult, err error) {
 	results = make([]WriteResult, 0)
 


### PR DESCRIPTION
- **refactor: combine errors to give more detail**
- **feat: implement join function that supports older go versions**
